### PR TITLE
deprecation notice

### DIFF
--- a/developer-guide/models-pricing/deprecations.mdx
+++ b/developer-guide/models-pricing/deprecations.mdx
@@ -49,8 +49,10 @@ Detailed deprecation policy and migration guide coming soon.
 
 Currently available models:
 - **Fish Audio S1** (Recommended) - Latest generation with best performance
-- **speech-1.6** - Previous generation, stable for existing integrations
-- **speech-1.5** - Earlier generation, maintained for compatibility
+
+## Deprecated Models
+- **speech-1.6** - Fish Speech v1.6 will be deprecated on February, 28th, 2026
+- **speech-1.5** - Fish Speech v1.5 will be deprecated on February, 28th, 2026
 
 <Note>
 We strongly recommend using **Fish Audio S1** for all new projects to access the latest capabilities and performance improvements.

--- a/developer-guide/models-pricing/models-overview.mdx
+++ b/developer-guide/models-pricing/models-overview.mdx
@@ -55,24 +55,6 @@ Fish Audio offers state-of-the-art text-to-speech models optimized for different
   - Full emotional control capabilities
 </Card>
 
-### Legacy Models
-
-<CardGroup cols={2}>
-  <Card title="speech-1.6" icon="clock-rotate-left">
-    **Fish Speech 1.6** - Previous generation model
-    - Stable and production-tested
-    - Good performance for standard use cases
-    - Basic emotional control
-  </Card>
-
-  <Card title="speech-1.5" icon="clock-rotate-left">
-    **Fish Speech 1.5** - Earlier generation model
-    - Reliable performance
-    - Limited to basic emotions
-    - Lower resource requirements
-  </Card>
-</CardGroup>
-
 <Note>
 We recommend using `s1` for all new projects to access the latest capabilities and performance improvements. Legacy models remain available for existing integrations.
 </Note>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added deprecation notices for speech-1.6 and speech-1.5 models with end-of-life date of February 28, 2026.
* Reorganized models documentation to streamline focus on currently supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->