### PR TITLE
docs: update concurrency tier thresholds

### DIFF
--- a/developer-guide/models-pricing/pricing-and-rate-limits.mdx
+++ b/developer-guide/models-pricing/pricing-and-rate-limits.mdx
@@ -82,6 +82,10 @@ These limits help us ensure fair usage and maintain service quality for all user
 | High Volume | ≥ $1,000 paid     | 50 requests         |
 | Enterprise | Custom             | Custom limits       |
 
+<Tip>
+    Concurrency tiers unlock as soon as your total prepaid amount reaches the threshold. You do not need to spend the full balance first. If your workload needs a higher concurrency tier, you can top up in advance to unlock the next tier immediately.
+</Tip>
+
 <Note>
     Please reach out to our team to enable enterprise volume pricing, rate limits, and billing.
 </Note>

--- a/developer-guide/models-pricing/pricing-and-rate-limits.mdx
+++ b/developer-guide/models-pricing/pricing-and-rate-limits.mdx
@@ -79,6 +79,7 @@ These limits help us ensure fair usage and maintain service quality for all user
 |------------|--------------------|---------------------|
 | Starter    | < $100 paid        | 5 requests          |
 | Elevated   | ≥ $100 paid        | 15 requests         |
+| High Volume | ≥ $1,000 paid     | 50 requests         |
 | Enterprise | Custom             | Custom limits       |
 
 <Note>


### PR DESCRIPTION
## Summary
- add a new high-volume concurrency tier for users with at least $1,000 paid
- clarify that concurrency tiers unlock once the prepaid amount reaches the threshold
- explain that users can top up in advance to unlock a higher tier without spending the full balance first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added High Volume concurrency tier (50 concurrent requests) for accounts with ≥$1,000 in paid charges.
  * Clarified that concurrency tiers unlock immediately upon reaching the spending threshold and that prepaying in advance can activate the next tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->