### PR TITLE
Use full https:// URL in skill install commands

### DIFF
--- a/developer-guide/resources/agent-quickstart.mdx
+++ b/developer-guide/resources/agent-quickstart.mdx
@@ -22,12 +22,12 @@ In most cases, agents should read `llms.txt` first and only fetch `llms-full.txt
 For coding agents that support [Agent Skills](https://github.com/vercel-labs/skills) (Claude Code, Cursor, Windsurf, Codex, and others), install the ready-made raw-API skill with a single command:
 
 ```bash
-npx skills add docs.fish.audio --skill fish-audio-api
+npx skills add https://docs.fish.audio --skill fish-audio-api
 ```
 
 The skill teaches the agent how to call the Fish Audio REST and WebSocket APIs directly from `curl`, Python, Node.js, or any HTTP client — no SDK required. It covers authentication, every endpoint in our [OpenAPI schema](https://docs.fish.audio/api-reference/openapi.json), MessagePack vs JSON vs multipart encoding rules, multi-speaker dialogue, and the WebSocket streaming protocol.
 
-Discovery endpoint: [/.well-known/agent-skills/index.json](https://docs.fish.audio/.well-known/agent-skills/index.json). Run `npx skills add docs.fish.audio` (without `--skill`) to install every skill published here, including the auto-generated product overview skill.
+Discovery endpoint: [/.well-known/agent-skills/index.json](https://docs.fish.audio/.well-known/agent-skills/index.json). Run `npx skills add https://docs.fish.audio` (without `--skill`) to install every skill published here, including the auto-generated product overview skill.
 
 ## Retrieval Order
 

--- a/developer-guide/resources/coding-agents.mdx
+++ b/developer-guide/resources/coding-agents.mdx
@@ -44,7 +44,7 @@ Fish Audio publishes a ready-made [Agent Skill](https://github.com/vercel-labs/s
 <Tabs>
   <Tab title="Install the raw-API skill">
     ```bash
-    npx skills add docs.fish.audio --skill fish-audio-api
+    npx skills add https://docs.fish.audio --skill fish-audio-api
     ```
 
     This installs the skill into your agent's local skill directory (for example `~/.claude/skills/fish-audio-api/`). Once installed, ask your agent to "call the Fish Audio TTS API with curl" or "stream TTS over WebSocket in Python" and it will follow the skill's conventions.
@@ -52,7 +52,7 @@ Fish Audio publishes a ready-made [Agent Skill](https://github.com/vercel-labs/s
 
   <Tab title="Install all Fish Audio skills">
     ```bash
-    npx skills add docs.fish.audio
+    npx skills add https://docs.fish.audio
     ```
 
     Installs every skill advertised at [/.well-known/agent-skills/index.json](https://docs.fish.audio/.well-known/agent-skills/index.json), including the auto-generated product overview skill and the raw-API skill.
@@ -62,8 +62,8 @@ Fish Audio publishes a ready-made [Agent Skill](https://github.com/vercel-labs/s
     The discovery index lives at [/.well-known/agent-skills/index.json](https://docs.fish.audio/.well-known/agent-skills/index.json) and each skill's raw markdown is served at [/.well-known/agent-skills/&lt;skill&gt;/SKILL.md](https://docs.fish.audio/.well-known/agent-skills/fish-audio-api/SKILL.md). Review the skill content first, then install with:
 
     ```bash
-    npx skills add docs.fish.audio --list          # show available skills
-    npx skills add docs.fish.audio --skill fish-audio-api
+    npx skills add https://docs.fish.audio --list          # show available skills
+    npx skills add https://docs.fish.audio --skill fish-audio-api
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

- The documented install command `npx skills add docs.fish.audio --skill fish-audio-api` actually fails — the `skills` CLI treats bare hostnames without a scheme as git shorthand (`owner/repo`) and attempts to clone, never reaching the well-known HTTP discovery path.
- Replace every `npx skills add docs.fish.audio …` occurrence in the docs with the scheme-qualified form `npx skills add https://docs.fish.audio …`, which routes through the CLI's `WellKnownProvider` and fetches `/.well-known/agent-skills/index.json` as intended.

## Test plan

- [ ] `npx skills add https://docs.fish.audio --skill fish-audio-api` completes and installs the skill into `~/.claude/skills/fish-audio-api/`
- [ ] `npx skills add https://docs.fish.audio --list` prints `fish-audio-api` in the available-skills list
- [ ] The two docs pages render correctly:
  - [developer-guide/resources/agent-quickstart.mdx](developer-guide/resources/agent-quickstart.mdx)
  - [developer-guide/resources/coding-agents.mdx](developer-guide/resources/coding-agents.mdx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Agent Skills installation instructions across multiple developer guides to use the proper discovery URL format, ensuring consistency and accuracy in installation command examples for both individual and bulk skill deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->