### PR TITLE
fix: replace dead E-girl voice ID with working reference

### DIFF
--- a/developer-guide/getting-started/quickstart.mdx
+++ b/developer-guide/getting-started/quickstart.mdx
@@ -201,10 +201,10 @@ Choose a voice to try:
 
 <Tabs>
   <Tab title="E-Girl Voice">
-    From: https://fish.audio/m/8ef4a238714b45718ce04243307c57a7
+    From: https://fish.audio/m/ca3007f96ae7499ab87d27ea3599956a
 
     ```bash
-    export REFERENCE_ID="8ef4a238714b45718ce04243307c57a7"
+    export REFERENCE_ID="ca3007f96ae7499ab87d27ea3599956a"
     ```
   </Tab>
 

--- a/snippets/audio-transcript.jsx
+++ b/snippets/audio-transcript.jsx
@@ -8,7 +8,7 @@ export const AudioTranscript = ({ voices, page }) => {
 
         const baseUrl = 'https://pub-b995142090474379a930b856ab79b4d4.r2.dev/audio';
         const pageVoices = [
-          { id: '8ef4a238714b45718ce04243307c57a7', name: 'E-girl' },
+          { id: 'ca3007f96ae7499ab87d27ea3599956a', name: 'E-girl' },
           { id: '802e3bc2b27e49c2995d23ef70e6ac89', name: 'Energetic Male' },
           { id: '933563129e564b19a115bedd57b7406a', name: 'Sarah' },
           { id: 'bf322df2096a46f18c579d0baa36f41d', name: 'Adrian' },

--- a/speaker-config.yaml
+++ b/speaker-config.yaml
@@ -5,7 +5,7 @@
 
 # Voice Configuration (map of voice ID -> display name)
 voices:
-  8ef4a238714b45718ce04243307c57a7: E-girl
+  ca3007f96ae7499ab87d27ea3599956a: E-girl
   802e3bc2b27e49c2995d23ef70e6ac89: Energetic Male
   933563129e564b19a115bedd57b7406a: Sarah
   bf322df2096a46f18c579d0baa36f41d: Adrian


### PR DESCRIPTION
## Problem

The voice reference `8ef4a238714b45718ce04243307c57a7` (E-girl) is no longer valid in Fish Audio. The TTS API returns:

400 Bad Request
{ "message": "Reference not found" }

This broke the GitHub Actions `TTS` workflow (see [run 27671547106](https://github.com/fishaudio/docs/actions/runs/27671547106/job/81836813539)). Because `speak-mintlify` fails the entire MDX file on the first failed voice, **none** of the 6 voices' mp3s got generated for any page touched after the regression. End result: Listen-to-Page widget on pages like Quick Start hits 404 in R2 and throws `NotSupportedError` in the browser.

## Fix

Replace the dead ID with a verified working reference `ca3007f96ae7499ab87d27ea3599956a` in 3 places:

- `speaker-config.yaml` — CI generation list
- `snippets/audio-transcript.jsx` — frontend fallback voice list (used when MDX uses `<AudioTranscript page="..." />`)
- `developer-guide/getting-started/quickstart.mdx` — E-Girl Voice tab demo strings

## What auto-updates after merge

The `TTS` workflow runs on merge to main and:
1. Regenerates mp3s for all MDX files with the new voice ID
2. Opens a follow-up `chore: update TTS Audio` PR rewriting the `voices` arrays in MDX files (e.g. `contributing.mdx`)

That follow-up PR also needs to be merged.

## Test plan

- [x] Verified new voice ID on fish.audio
- [x] Local `mint dev` — Quick Start widget requests `audio/.../ca3007....mp3`; Tab demo strings show new ID
- [ ] Post-merge: TTS workflow run succeeds
- [ ] Post-merge: Listen-to-Page on `docs.fish.audio/.../quickstart` plays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated voice customization examples with new identifiers

* **Chores**
  * Updated E-Girl voice configuration identifiers across settings and references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->