### PR TITLE
docs: address week-1 onboarding feedback

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1345,7 +1345,11 @@
                       "type": "string"
                     },
                     "train_mode": {
-                      "const": "fast",
+                      "default": "full",
+                      "enum": [
+                        "fast",
+                        "full"
+                      ],
                       "title": "Train Mode",
                       "type": "string"
                     },
@@ -1643,7 +1647,7 @@
                       "type": "string"
                     },
                     "train_mode": {
-                      "default": "fast",
+                      "default": "full",
                       "enum": [
                         "fast",
                         "full"
@@ -4048,7 +4052,7 @@
             "type": "string"
           },
           "train_mode": {
-            "default": "fast",
+            "default": "full",
             "enum": [
               "fast",
               "full"

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -1345,11 +1345,7 @@
                       "type": "string"
                     },
                     "train_mode": {
-                      "default": "full",
-                      "enum": [
-                        "fast",
-                        "full"
-                      ],
+                      "const": "fast",
                       "title": "Train Mode",
                       "type": "string"
                     },
@@ -1647,7 +1643,7 @@
                       "type": "string"
                     },
                     "train_mode": {
-                      "default": "full",
+                      "default": "fast",
                       "enum": [
                         "fast",
                         "full"
@@ -4052,7 +4048,7 @@
             "type": "string"
           },
           "train_mode": {
-            "default": "full",
+            "default": "fast",
             "enum": [
               "fast",
               "full"

--- a/developer-guide/core-features/emotions.mdx
+++ b/developer-guide/core-features/emotions.mdx
@@ -60,9 +60,17 @@ The S2 TTS models will interpret these markers and adjust the voice accordingly.
 
 <AdvancedEmotions />
 
-### Tone Markers (5 expressions)
+## Sound & Delivery Markers
 
-Control volume and intensity:
+These markers aren't emotions — they shape *how* a line is delivered, add natural human sounds, or layer in ambient effects. Combine them with the emotion cues above.
+
+### Tone Markers (6 expressions)
+
+Control volume, intensity, and emphasis. Place `[emphasis]` right before the word or phrase you want to stress:
+
+```text
+This is [emphasis] really important.
+```
 
 <ToneMarkers />
 

--- a/features/realtime-streaming.mdx
+++ b/features/realtime-streaming.mdx
@@ -151,13 +151,25 @@ for chunk in client.tts.stream_websocket(script(), reference_id="YOUR_VOICE_ID")
 
 Both streaming paths take a `latency` mode:
 
-- `latency="balanced"` (default) — lowest time-to-first-audio. Use it for voice agents and live LLM output.
+- `latency="balanced"` (Python SDK default) — lowest time-to-first-audio. Use it for voice agents and live LLM output.
 - `latency="normal"` — slightly higher latency, best audio quality. Use it for narration where you can afford a beat.
 
 ```python
 for chunk in client.tts.stream_websocket(llm_tokens(), latency="balanced"):
     ...
 ```
+
+<Warning>
+  **Set `latency` explicitly for real-time use.** The Python SDK defaults to `balanced`, but the raw HTTP/WebSocket API defaults to `normal`, which is tuned for quality and noticeably increases time-to-first-audio — you may wait several seconds for the first chunk. If you call the API directly, or through a third-party integration such as the LiveKit plugin, pass `balanced` (or `low`) for interactive latency.
+</Warning>
+
+The available modes differ slightly between the raw API and the SDK:
+
+| Mode       | Raw HTTP/WebSocket API | Python SDK    | Behavior                                       |
+| ---------- | ---------------------- | ------------- | ---------------------------------------------- |
+| `low`      | Supported              | Not available | Lowest latency                                 |
+| `balanced` | Supported              | Default       | Reduced latency — recommended for real-time    |
+| `normal`   | Default                | Supported     | Best quality, highest time-to-first-audio      |
 
 For finer control, pass a `TTSConfig` with chunk tuning. Smaller chunks emit audio sooner (lower latency); larger chunks give the model more context (smoother prosody):
 

--- a/features/text-to-speech.mdx
+++ b/features/text-to-speech.mdx
@@ -215,9 +215,14 @@ audio = client.tts.convert(
 
 `latency` trades stability for speed; `chunk_length` controls how much text the engine batches before it starts generating.
 
-- `latency="balanced"` (default) — lower time-to-first-audio (~300ms). Good for interactive use.
+- `latency="balanced"` (Python SDK default) — lower time-to-first-audio (~300ms). Good for interactive use.
 - `latency="normal"` — most stable output, at slightly higher latency.
+- `latency="low"` (raw API only) — lowest latency.
 - `chunk_length` (`100`–`300`, default `200`) — smaller chunks start audio sooner; larger chunks are more efficient for long text.
+
+<Note>
+  The raw HTTP/WebSocket API defaults `latency` to `normal` (quality-tuned), while the Python SDK defaults to `balanced`. For real-time use over the raw API, set `latency` to `balanced` or `low` explicitly — see [Tune latency vs. quality](/features/realtime-streaming#tune-latency-vs-quality).
+</Note>
 
 <CodeGroup>
 ```python Python

--- a/snippets/emotion-list-tones-s2.mdx
+++ b/snippets/emotion-list-tones-s2.mdx
@@ -5,3 +5,4 @@
 | Screaming  | `[screaming]`       | Very loud, panicked  | Emergencies, fear          |
 | Whispering | `[whispering]`      | Very soft, secretive | Secrets, quiet scenes      |
 | Soft       | `[soft tone]`       | Gentle, quiet        | Comfort, lullabies         |
+| Emphasis   | `[emphasis]`        | Stress a word/phrase | Highlighting key words     |


### PR DESCRIPTION
## Summary

Documentation fixes from Cale's week-1 "fresh eyes" onboarding feedback. Three independent, low-risk docs fixes.

**Opened as a draft for review before merge.**

### Changes

1. **`[emphasis]` documented** — previously only mentioned in the changelog and models overview. Added as a Tone Marker with a usage example on the Emotion Control page.
2. **"Special Effects" placement** — Tone Markers, Audio Effects, and Special Effects were nested under "Complete Emotion Reference" alongside actual emotions. Moved them into a new **Sound & Delivery Markers** section, since they aren't emotions.
3. **Latency guidance** — S2 over WebSocket can take several seconds to first audio because the raw HTTP/WebSocket API defaults `latency` to `normal` (the Python SDK defaults to `balanced`). Added a warning and a per-surface support matrix so real-time users (e.g. via the LiveKit plugin) know to set `balanced`/`low`.

### Dropped from this PR — `train_mode` fix moved to backend

The Create Model reference advertises `train_mode: "full"` in the response, but TTS creation only supports `"fast"`. I originally fixed this in `openapi.json`, but **`openapi.json` is a generated artifact** — `scripts/update-openapi.mjs` pulls it from `https://api.fish.audio/openapi.json`, and the `check-openapi` CI job regenerates it and fails if the committed file differs. A hand-edit here can never pass CI.

The fix must land in the backend and be deployed:
- **`platform-api/apps/models/schemas.py:103`** — `train_mode: Literal["fast", "full"] = "full"` (the response model that emits `full`).

Once deployed, the docs spec will pick up `fast` automatically on the next regen. Tracking separately.

### Other follow-ups (not in this PR)

- **Emotion advice needs verification:** `emotions.mdx` advises *"Add appropriate text after sound effects (e.g., 'Ha ha' after laughing)"* — likely leftover S1 guidance. Left unchanged pending confirmation of actual S2 behavior.

### Validation

`check-openapi`, Mintlify deployment, and CodeRabbit all pass. Mintlify preview built successfully.
