### PR TITLE
fix(tts): stop CI crash by dropping cleanup/PR steps, convert contrib…

### DIFF
--- a/.github/workflows/tts.yaml
+++ b/.github/workflows/tts.yaml
@@ -27,23 +27,9 @@ jobs:
           S3_PUBLIC_URL: ${{ vars.S3_PUBLIC_URL }}
           S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
 
-      - name: Cleanup Orphaned Audio
-        run: npx speak-mintlify@latest cleanup .
-        env:
-          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
-          S3_BUCKET: ${{ secrets.S3_BUCKET }}
-          S3_PUBLIC_URL: ${{ vars.S3_PUBLIC_URL }}
-          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: 'chore: update TTS audio'
-          title: 'chore: update TTS Audio'
-          body: 'Auto-generated TTS audio for updated documentation'
-          branch: chore/tts-updates
-          delete-branch: true
-          token: ${{ secrets.BOT_TOKEN }}
-          author: ${{ vars.BOT_NAME }} <${{ vars.BOT_EMAIL }}>
-          committer: ${{ vars.BOT_NAME }} <${{ vars.BOT_EMAIL }}>
+      # NOTE: the former "Cleanup Orphaned Audio" and "Create Pull Request"
+      # steps were removed. Pages now use the runtime page= form
+      # (<AudioTranscript page="..." />): the cleanup command cannot see those
+      # references and would delete live audio, and there is no MDX change to
+      # open a PR for. `generate` still uploads the audio to R2, which is all
+      # the page= form needs.

--- a/contributing.mdx
+++ b/contributing.mdx
@@ -5,39 +5,9 @@ icon: "code-pull-request"
 ---
 import { AudioTranscript } from '/snippets/audio-transcript.jsx';
 
-{/* speak-mintlify-hash: cdb589f221b74134788267368baaa9b7d15416a5af87eebf7141010c7ed8320f */}
-<AudioTranscript voices={[
-    {
-      "id": "8ef4a238714b45718ce04243307c57a7",
-      "name": "E-girl",
-      "url": "https://pub-b995142090474379a930b856ab79b4d4.r2.dev/audio/contributing/8ef4a238714b45718ce04243307c57a7.mp3"
-    },
-    {
-      "id": "802e3bc2b27e49c2995d23ef70e6ac89",
-      "name": "Energetic Male",
-      "url": "https://pub-b995142090474379a930b856ab79b4d4.r2.dev/audio/contributing/802e3bc2b27e49c2995d23ef70e6ac89.mp3"
-    },
-    {
-      "id": "933563129e564b19a115bedd57b7406a",
-      "name": "Sarah",
-      "url": "https://pub-b995142090474379a930b856ab79b4d4.r2.dev/audio/contributing/933563129e564b19a115bedd57b7406a.mp3"
-    },
-    {
-      "id": "bf322df2096a46f18c579d0baa36f41d",
-      "name": "Adrian",
-      "url": "https://pub-b995142090474379a930b856ab79b4d4.r2.dev/audio/contributing/bf322df2096a46f18c579d0baa36f41d.mp3"
-    },
-    {
-      "id": "b347db033a6549378b48d00acb0d06cd",
-      "name": "Selene",
-      "url": "https://pub-b995142090474379a930b856ab79b4d4.r2.dev/audio/contributing/b347db033a6549378b48d00acb0d06cd.mp3"
-    },
-    {
-      "id": "536d3a5e000945adb7038665781a4aca",
-      "name": "Ethan",
-      "url": "https://pub-b995142090474379a930b856ab79b4d4.r2.dev/audio/contributing/536d3a5e000945adb7038665781a4aca.mp3"
-    }
-  ]} />
+<Visibility for="humans">
+  <AudioTranscript page="contributing" />
+</Visibility>
 
 
 # Contributing to Fish Audio


### PR DESCRIPTION
Description

## What
- Remove the `Cleanup Orphaned Audio` and `Create Pull Request` steps from the TTS workflow.
- Convert `contributing.mdx` from the legacy `voices={...}` form to the runtime `page=` form.

## Why
The TTS workflow was failing on every run. The `Cleanup Orphaned Audio` step
crashed with `Unexpected closing slash '/' in tag`, which then skipped the
`Create Pull Request` step (no `if: always()`), so no audio PR was ever opened.

Root cause is the page= migration (PR #68) being incompatible with the
`speak-mintlify` CLI workflow, which was built for the old `voices={...}` form:

- **Cleanup is wrong for page= pages.** It figures out "which audio is still
  referenced" by reading `voices` URLs from the MDX. The `page=` form has no
  `voices` attribute, so cleanup sees those pages as referencing nothing and
  would delete live audio. (It only ever crashed before reaching that point.)
- **The crash itself** comes from `generate` re-injecting the component: it
  un-nests `<AudioTranscript>` out of its `<Visibility for="humans">` wrapper
  and leaves a dangling `</Visibility>`, which is invalid MDX.
- **No PR is needed** for page= pages: URLs are resolved at runtime by
  `audio-transcript.jsx`, so the MDX is never rewritten — there is nothing to
  commit.

`generate` still runs and uploads the audio to R2, which is all the page= form
needs.

`contributing.mdx` was the last file still on the old `voices={...}` form (and
still pointed at the dead E-girl ID). Converting it to `page=` makes all audio
pages consistent and lets it follow the current voice list.

## Net change
Only `.github/workflows/tts.yaml` and `contributing.mdx` (the E-girl voice ID
fix already landed on main via #90).

## Notes / follow-ups (out of scope)
- `generate` still re-synthesizes every page each run (~2.5h) because its
  skip/dedup needs metadata in the MDX, which the page= form doesn't carry.
- Old voice-ID audio is left in R2 (harmless; nothing references it).
- The voice list still lives in two places (`audio-transcript.jsx` +
  `speaker-config.yaml`) and must be kept in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified TTS audio generation workflow by consolidating steps.
  * Updated audio transcript rendering in contributing documentation to use dynamic page-based approach with improved visibility controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->