### PR TITLE
Update voice design params to show 150 instead of 300

### DIFF
--- a/.mintlify/skills/fish-audio-api/SKILL.md
+++ b/.mintlify/skills/fish-audio-api/SKILL.md
@@ -256,7 +256,7 @@ Response: JSON `{ candidates: VoiceDesignCandidate[] }`. Each candidate includes
 | Field                     | Type           | Default      | Notes                                                                       |
 | ------------------------- | -------------- | ------------ | --------------------------------------------------------------------------- |
 | `instruction`             | string         | — (required) | Voice design prompt. 1 to 2000 characters.                                  |
-| `reference_text`          | string \| null | null         | Optional preview text to read in the generated voice. Up to 300 characters. |
+| `reference_text`          | string \| null | null         | Optional preview text to read in the generated voice. Up to 150 characters. |
 | `language`                | string \| null | null         | Optional language hint such as `en`, `zh`, or `ja`.                         |
 | `n`                       | int            | 2            | Number of candidates. Range: 1 to 4.                                        |
 | `speed`                   | number         | 1.0          | Speaking speed multiplier. Must be greater than 0 and at most 3.             |

--- a/api-reference/endpoint/openapi-v1/voice-design.mdx
+++ b/api-reference/endpoint/openapi-v1/voice-design.mdx
@@ -42,7 +42,7 @@ curl --request POST https://api.fish.audio/v1/voice-design \
 ## Usage notes
 
 - `instruction` is required and must be 1 to 2000 characters.
-- `reference_text` is optional preview text and can be up to 300 characters.
+- `reference_text` is optional preview text and can be up to 150 characters.
 - `n` controls how many candidates are returned. The supported range is 1 to 4.
 - `seed` is optional and can help reproduce candidate generation.
 - The endpoint is stateless: it does not create batches, samples, voice models, or presigned URLs.


### PR DESCRIPTION
Fixes error 400: if trying to use any value over 150 for the voice design API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Voice Design API documentation: The `reference_text` field maximum length has been reduced from 300 to 150 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->