### PR TITLE
docs: document [emphasis] tone marker and restructure delivery markers

### DIFF
--- a/developer-guide/core-features/emotions.mdx
+++ b/developer-guide/core-features/emotions.mdx
@@ -60,9 +60,17 @@ The S2 TTS models will interpret these markers and adjust the voice accordingly.
 
 <AdvancedEmotions />
 
-### Tone Markers (5 expressions)
+## Sound & Delivery Markers
 
-Control volume and intensity:
+These markers aren't emotions — they shape _how_ a line is delivered, add natural human sounds, or layer in ambient effects. Combine them with the emotion cues above.
+
+### Tone Markers (6 expressions)
+
+Control volume, intensity, and emphasis. Place `[emphasis]` right before the word or phrase you want to stress:
+
+```text
+This is [emphasis] really important.
+```
 
 <ToneMarkers />
 

--- a/developer-guide/core-features/emotions.mdx
+++ b/developer-guide/core-features/emotions.mdx
@@ -74,7 +74,7 @@ This is [emphasis] really important.
 
 <ToneMarkers />
 
-### Audio Effects (10 expressions)
+### Audio Effects (11 expressions)
 
 Add natural human sounds:
 

--- a/snippets/emotion-list-effects-s2.mdx
+++ b/snippets/emotion-list-effects-s2.mdx
@@ -10,3 +10,4 @@
 | Gasping       | `[gasping]`       | Sharp intake of breath       | gasp           |
 | Yawning       | `[yawning]`       | Tired sound                  | yawn           |
 | Snoring       | `[snoring]`       | Sleep sound                  | zzz            |
+| Clear Throat  | `[clear throat]`  | Throat-clearing sound        | ahem           |

--- a/snippets/emotion-list-tones-s2.mdx
+++ b/snippets/emotion-list-tones-s2.mdx
@@ -5,3 +5,4 @@
 | Screaming  | `[screaming]`       | Very loud, panicked  | Emergencies, fear          |
 | Whispering | `[whispering]`      | Very soft, secretive | Secrets, quiet scenes      |
 | Soft       | `[soft tone]`       | Gentle, quiet        | Comfort, lullabies         |
+| Emphasis   | `[emphasis]`        | Stress a word/phrase | Highlighting key words     |


### PR DESCRIPTION
## Changes

1. Add `[emphasis]` to the S2 tone marker table with a usage example. It is currently shown in the models overview and changelog but never documented on the Emotion Control page.
2. Move Tone Markers, Audio Effects, and Special Effects out of "Complete Emotion Reference" into a new "Sound & Delivery Markers" section. They shape delivery and add sounds; they are not emotions.
3. Add `[clear throat]` to the S2 audio effects table.

## Validation

- Prettier clean on all added lines (the two pre-existing unformatted blocks in emotions.mdx were left untouched to keep the diff minimal)
- `mint broken-links` reports issues only in pre-existing `temp/` files
- Verified locally with `mint dev`: heading hierarchy, sidebar TOC, and both new table rows render as intended