### PR TITLE
docs: update public voice reference ID

### DIFF
--- a/.mintlify/skills/fish-audio-sdk/references/text-to-speech.md
+++ b/.mintlify/skills/fish-audio-sdk/references/text-to-speech.md
@@ -17,7 +17,7 @@ save(audio, "out.mp3")
 # Use a specific voice model by id
 audio = client.tts.convert(
     text="Using a saved voice.",
-    reference_id="802e3bc2b27e49c2995d23ef70e6ac89",
+    reference_id="9a9cf47702da476aa4629e2506d4a857",
 )
 
 # Pick a model and adjust speed
@@ -95,7 +95,7 @@ await play(audio);
 const audio2 = await client.textToSpeech.convert(
   {
     text: "Using a saved voice.",
-    reference_id: "802e3bc2b27e49c2995d23ef70e6ac89",
+    reference_id: "9a9cf47702da476aa4629e2506d4a857",
   },
   "s1" // <-- positional backend, not { backend: "s1" }
 );

--- a/api-reference/asyncapi.yml
+++ b/api-reference/asyncapi.yml
@@ -144,7 +144,7 @@ components:
               text: ""
               format: mp3
               chunk_length: 300
-              reference_id: "802e3bc2b27e49c2995d23ef70e6ac89"
+              reference_id: "9a9cf47702da476aa4629e2506d4a857"
               latency: normal
         - name: Full Configuration with All Options
           payload:
@@ -165,7 +165,7 @@ components:
               mp3_bitrate: 128
               opus_bitrate: -1000
               references: []
-              reference_id: "802e3bc2b27e49c2995d23ef70e6ac89"
+              reference_id: "9a9cf47702da476aa4629e2506d4a857"
               latency: normal
               prosody:
                 speed: 1.2

--- a/api-reference/sdk/python/overview.mdx
+++ b/api-reference/sdk/python/overview.mdx
@@ -97,7 +97,7 @@ asyncio.run(main())
 # Use a specific voice by ID
 audio = client.tts.convert(
     text="Custom voice",
-    reference_id="802e3bc2b27e49c2995d23ef70e6ac89"
+    reference_id="9a9cf47702da476aa4629e2506d4a857"
 )
 ```
 

--- a/api-reference/sdk/python/types.mdx
+++ b/api-reference/sdk/python/types.mdx
@@ -205,7 +205,7 @@ All parameters have sensible defaults.
 - `chunk_length` - Characters per generation chunk. Range: 100-300. Default: 200.
   Lower values = faster initial response, higher values = better quality
 - `latency` - Generation mode. Options: "normal" (higher quality), "balanced" (faster). Default: "balanced"
-- `reference_id` - Voice model ID from fish.audio (e.g., "802e3bc2b27e49c2995d23ef70e6ac89").
+- `reference_id` - Voice model ID from fish.audio (e.g., "9a9cf47702da476aa4629e2506d4a857").
   Find IDs in voice URLs or via voices.list()
 - `references` - List of reference audio samples for instant voice cloning. Default: []
 - `prosody` - Speech speed and volume settings. Default: None (uses natural prosody)

--- a/archive/python-sdk-legacy/text-to-speech.mdx
+++ b/archive/python-sdk-legacy/text-to-speech.mdx
@@ -57,8 +57,8 @@ with open("custom_voice.mp3", "wb") as f:
 
 The `reference_id` is the model ID from the URL when viewing a model on Fish Audio:
 
-- Model URL: `https://fish.audio/m/802e3bc2b27e49c2995d23ef70e6ac89`
-- Reference ID: `802e3bc2b27e49c2995d23ef70e6ac89`
+- Model URL: `https://fish.audio/m/9a9cf47702da476aa4629e2506d4a857`
+- Reference ID: `9a9cf47702da476aa4629e2506d4a857`
 
 You can also get model IDs programmatically:
 

--- a/developer-guide/getting-started/quickstart.mdx
+++ b/developer-guide/getting-started/quickstart.mdx
@@ -209,10 +209,10 @@ Choose a voice to try:
   </Tab>
 
   <Tab title="Energetic Male">
-    From: https://fish.audio/m/802e3bc2b27e49c2995d23ef70e6ac89
+    From: https://fish.audio/m/9a9cf47702da476aa4629e2506d4a857
 
     ```bash
-    export REFERENCE_ID="802e3bc2b27e49c2995d23ef70e6ac89"
+    export REFERENCE_ID="9a9cf47702da476aa4629e2506d4a857"
     ```
   </Tab>
 </Tabs>

--- a/features/text-to-speech.mdx
+++ b/features/text-to-speech.mdx
@@ -85,7 +85,7 @@ Pass a **voice model id** (`reference_id`). Find ids in the [Voice Library](/ove
 ```python Python
 audio = client.tts.convert(
     text="This uses a specific voice.",
-    reference_id="802e3bc2b27e49c2995d23ef70e6ac89",
+    reference_id="9a9cf47702da476aa4629e2506d4a857",
 )
 ```
 
@@ -96,7 +96,7 @@ curl --request POST https://api.fish.audio/v1/tts \
   --header "model: s2-pro" \
   --data '{
     "text": "This uses a specific voice.",
-    "reference_id": "802e3bc2b27e49c2995d23ef70e6ac89",
+    "reference_id": "9a9cf47702da476aa4629e2506d4a857",
     "format": "mp3"
   }' \
   --output out.mp3

--- a/snippets/audio-transcript.jsx
+++ b/snippets/audio-transcript.jsx
@@ -9,7 +9,7 @@ export const AudioTranscript = ({ voices, page }) => {
         const baseUrl = 'https://pub-b995142090474379a930b856ab79b4d4.r2.dev/audio';
         const pageVoices = [
           { id: 'ca3007f96ae7499ab87d27ea3599956a', name: 'E-girl' },
-          { id: '802e3bc2b27e49c2995d23ef70e6ac89', name: 'Energetic Male' },
+          { id: '9a9cf47702da476aa4629e2506d4a857', name: 'Energetic Male' },
           { id: '933563129e564b19a115bedd57b7406a', name: 'Sarah' },
           { id: 'bf322df2096a46f18c579d0baa36f41d', name: 'Adrian' },
           { id: 'b347db033a6549378b48d00acb0d06cd', name: 'Selene' },

--- a/speaker-config.yaml
+++ b/speaker-config.yaml
@@ -6,7 +6,7 @@
 # Voice Configuration (map of voice ID -> display name)
 voices:
   ca3007f96ae7499ab87d27ea3599956a: E-girl
-  802e3bc2b27e49c2995d23ef70e6ac89: Energetic Male
+  9a9cf47702da476aa4629e2506d4a857: Energetic Male
   933563129e564b19a115bedd57b7406a: Sarah
   bf322df2096a46f18c579d0baa36f41d: Adrian
   b347db033a6549378b48d00acb0d06cd: Selene

--- a/tests/cookbooks/harness.py
+++ b/tests/cookbooks/harness.py
@@ -15,7 +15,7 @@ from fishaudio import FishAudio as _FishAudio
 
 BASE_URL = "https://api.fish.audio"
 # Validated public voice ("Energetic Male"), used to fill <voice-id> placeholders.
-PUBLIC_VOICE = "802e3bc2b27e49c2995d23ef70e6ac89"
+PUBLIC_VOICE = "9a9cf47702da476aa4629e2506d4a857"
 _WORKSPACE_ENV = "/Users/shawnlai/project/fish-audio/.env"
 _LOCAL_KEYFILE = "/tmp/claude/fishdoctest/fishkey"
 

--- a/tests/js/run.mjs
+++ b/tests/js/run.mjs
@@ -14,7 +14,7 @@ import { SPECS } from "./specs.mjs";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FISH = resolve(HERE, "../..");
 const WS = resolve(FISH, "..");
-const PUBLIC_VOICE = "802e3bc2b27e49c2995d23ef70e6ac89";
+const PUBLIC_VOICE = "9a9cf47702da476aa4629e2506d4a857";
 
 function resolveKey() {
   if (process.env.FISH_API_KEY) return process.env.FISH_API_KEY.trim();


### PR DESCRIPTION
## Summary

- replace the old public voice reference ID with `9a9cf47702da476aa4629e2506d4a857`
- update all documentation examples, SDK references, configuration, and test harness constants

## Why

The previous public voice reference ID is no longer the intended voice used by the documentation examples.

## Impact

Users copying examples and tests running against the public voice will consistently use the new reference ID.

## Validation

- confirmed the old ID has zero remaining occurrences
- confirmed the new ID appears in all 16 expected locations across 11 files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated text-to-speech examples across SDK, API, quickstart, and feature guides to use the current specific voice reference.
  - Refreshed custom voice and voice model examples for consistency.

- **Bug Fixes**
  - Updated the “Energetic Male” voice mapping to the correct voice identifier.

- **Tests**
  - Updated test examples and validation settings to use the current public voice reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->