### PR TITLE
Document the product MCP server, drop the docs-MCP hooks

### DIFF
--- a/developer-guide/resources/agent-quickstart.mdx
+++ b/developer-guide/resources/agent-quickstart.mdx
@@ -74,7 +74,7 @@ npx skills add https://docs.fish.audio --list
 </CodeGroup>
 
 <Card title="AI Coding Agents — full guide" icon="robot" href="/developer-guide/resources/coding-agents" horizontal>
-  Targeting specific agents, the live-docs MCP server, skill-vs-MCP, and reading the skills before you install.
+  Targeting specific agents, the Fish Audio MCP server, and reading the skills before you install.
 </Card>
 
 ## Next steps

--- a/developer-guide/resources/coding-agents.mdx
+++ b/developer-guide/resources/coding-agents.mdx
@@ -76,54 +76,10 @@ Once installed, ask your agent in plain language — it will use the correct cli
 
 ## Or connect via MCP
 
-Prefer live documentation search inside your editor over a self-contained skill file? Connect the Fish Audio MCP server, which serves the latest docs to your agent.
-
-<Tabs>
-  <Tab title="Claude Code">
-    ```bash
-    claude mcp add --transport http fish-audio --scope project https://docs.fish.audio/mcp
-    ```
-
-    This writes a `.mcp.json` in your project root. Verify with `claude mcp list` (you should see `fish-audio`), then ask "What Fish Audio TTS models are available?"
-
-    <Accordion title="Installation scopes">
-      - **`--scope project`** (recommended): config in `.mcp.json`, version-controlled and shared with your team.
-      - **`--scope user`**: global across your projects, private to your account.
-      - **`--scope local`** (default): project-specific and private to you.
-    </Accordion>
-  </Tab>
-
-  <Tab title="Cursor">
-    Open the command palette (`Cmd/Ctrl+Shift+P`) → "Open MCP settings" → "Add custom MCP", and add:
-
-    ```json
-    {
-      "mcpServers": {
-        "fish-audio": { "url": "https://docs.fish.audio/mcp" }
-      }
-    }
-    ```
-
-    Save and reload Cursor, then ask "What Fish Audio TTS models are available?"
-  </Tab>
-
-  <Tab title="Windsurf">
-    Go to `Settings → Cascade → MCP Servers → View raw config` (`~/.codeium/windsurf/mcp_config.json`) and add:
-
-    ```json
-    {
-      "mcpServers": {
-        "fish-audio": { "url": "https://docs.fish.audio/mcp" }
-      }
-    }
-    ```
-
-    Save, refresh, then in Cascade ask "Search Fish Audio docs for TTS API usage."
-  </Tab>
-</Tabs>
+The [Fish Audio MCP server](/overview/mcp) at `https://api.fish.audio/mcp` gives your agent tools instead of docs: it can search the voice library, generate speech, and transcribe audio with your Fish Audio account (OAuth sign-in, no API key). See the [MCP server guide](/overview/mcp) for client setup and the tool list.
 
 <Note>
-  **Skill vs MCP:** the skill is a self-contained instruction file that works offline after install; MCP fetches the latest docs live. You can use both. This site also exposes [llms.txt](https://docs.fish.audio/llms.txt) and [llms-full.txt](https://docs.fish.audio/llms-full.txt) for agents that fetch docs directly.
+  This site also exposes [llms.txt](https://docs.fish.audio/llms.txt) and [llms-full.txt](https://docs.fish.audio/llms-full.txt) for agents that fetch docs directly.
 </Note>
 
 ## Next steps

--- a/docs.json
+++ b/docs.json
@@ -55,7 +55,8 @@
           {
             "group": "Platform (Web App)",
             "pages": [
-              "overview/platform"
+              "overview/platform",
+              "overview/mcp"
             ]
           },
           {
@@ -273,10 +274,7 @@
       "view",
       "chatgpt",
       "claude",
-      "perplexity",
-      "mcp",
-      "cursor",
-      "vscode"
+      "perplexity"
     ]
   },
   "fonts": {

--- a/overview/mcp.mdx
+++ b/overview/mcp.mdx
@@ -1,0 +1,98 @@
+---
+title: "MCP Server"
+description: "Connect Claude, Cursor, or any MCP client to your Fish Audio account — search voices, generate speech, and transcribe audio"
+icon: "plug"
+---
+
+The Fish Audio MCP server gives AI agents direct access to your Fish Audio account: they can browse the voice library, generate speech, and transcribe audio for you.
+
+- **Endpoint**: `https://api.fish.audio/mcp` (streamable HTTP)
+- **Authentication**: OAuth. Your MCP client opens a browser window and you sign in with your Fish Audio account — no API key required.
+- **Billing**: usage draws from your plan's package credits, exactly like the [web app](https://fish.audio/app). It does not consume developer API credits.
+
+## Connect
+
+<Tabs>
+  <Tab title="Claude Code">
+    ```bash
+    claude mcp add --transport http fish-audio https://api.fish.audio/mcp
+    ```
+
+    Run `/mcp` inside Claude Code to sign in, then ask "Generate a short greeting with a warm English voice."
+
+  </Tab>
+
+<Tab title="Claude.ai">
+  Go to **Settings → Connectors → Add custom connector** and enter
+  `https://api.fish.audio/mcp`. Claude walks you through the sign-in.
+</Tab>
+
+  <Tab title="Cursor">
+    Open the command palette (`Cmd/Ctrl+Shift+P`) → "Open MCP settings" → "Add custom MCP", and add:
+
+    ```json
+    {
+      "mcpServers": {
+        "fish-audio": { "url": "https://api.fish.audio/mcp" }
+      }
+    }
+    ```
+
+    Cursor prompts you to sign in on first use.
+
+  </Tab>
+
+  <Tab title="Codex CLI">
+    ```bash
+    codex mcp add fish-audio https://api.fish.audio/mcp
+    codex mcp login fish-audio
+    ```
+
+    `codex mcp login` opens the browser sign-in. Verify with `codex mcp list`.
+
+  </Tab>
+
+  <Tab title="Windsurf">
+    Go to `Settings → Cascade → MCP Servers → View raw config` (`~/.codeium/windsurf/mcp_config.json`) and add:
+
+    ```json
+    {
+      "mcpServers": {
+        "fish-audio": { "url": "https://api.fish.audio/mcp" }
+      }
+    }
+    ```
+
+  </Tab>
+</Tabs>
+
+## Try it
+
+Once connected, ask in plain language — the agent picks the right tools:
+
+<CardGroup cols={2}>
+  <Card title="Narrate a script" icon="microphone">
+    "Find a calm English narration voice and read intro.md aloud — give me the audio link."
+  </Card>
+
+  <Card title="Voice casting" icon="magnifying-glass">
+    "Show me the three most popular Japanese voices and play their samples."
+  </Card>
+
+  <Card title="Transcribe a recording" icon="waveform">
+    "Transcribe meeting.mp3 and summarize the action items." (the agent uploads the file, then transcribes it)
+  </Card>
+
+  <Card title="Check spend" icon="wallet">
+    "How many Fish Audio credits do I have left?"
+  </Card>
+</CardGroup>
+
+In coding agents like Claude Code and Codex, tools compose with the shell: the agent can download the generated audio URL with `curl`, upload local recordings for transcription, or batch-generate a directory of scripts.
+
+## Good to know
+
+- Add audio tags in square brackets inside the text to control delivery — `[whispering]`, `[excited]`, `[laughing]`. Tags are performed, never spoken.
+- If no voice is specified, a curated default voice for the requested language is used.
+- Generated audio is returned as a permanent URL; failed generations are refunded.
+- Local files can be transcribed too — the agent uploads them to a temporary slot that is deleted automatically after 7 days.


### PR DESCRIPTION
## Summary

- **New page `overview/mcp`** under Platform (Web App): the product MCP server at `api.fish.audio/mcp` — OAuth sign-in (no API key), playground-credit billing, per-client setup (Claude Code, Claude.ai, Cursor, Codex CLI, Windsurf), example prompts, and evergreen usage notes (audio tags, default voices, refunds, local-file transcription). Tool names and per-tool pricing are intentionally not enumerated — the toolset will keep evolving.
- **Removed the old docs.fish.audio/mcp support**: the `mcp` / `cursor` / `vscode` contextual options in docs.json, and the live-docs MCP setup section in the coding-agents guide (now a short pointer to the product MCP page; the llms.txt note is kept).
- agent-quickstart card description updated accordingly.

## Preview

Verified locally with `mint dev` (page renders, nav entry appears, no residual `docs.fish.audio/mcp` references outside package-lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)