### PR TITLE
Fix documentation repository link in contributing guide

### DIFF
--- a/contributing.mdx
+++ b/contributing.mdx
@@ -134,7 +134,7 @@ Documentation improvements are always welcome! This includes:
 - Adding new guides or tutorials
 - Translating documentation
 
-See our [documentation repository](https://github.com/fishaudio/fish-docs) to get started.
+See our [documentation repository](https://github.com/fishaudio/docs) to get started.
 
 ## Styleguides
 


### PR DESCRIPTION
`contributing.mdx` points anyone who wants to improve the documentation at `https://github.com/fishaudio/fish-docs`, but that repository returns 404. The documentation lives in this repository, `fishaudio/docs`.

Verified:

```
$ curl -s -o /dev/null -w "%{http_code}" https://github.com/fishaudio/fish-docs
404
$ curl -s -o /dev/null -w "%{http_code}" https://github.com/fishaudio/docs
200
```

One line changed, nothing else touched.

Heads up on CI: `check-openapi` fails here because the committed `api-reference/openapi.json` is behind `https://api.fish.audio/openapi.json`, which is what #107 updates. It is unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contribution guide with the correct documentation repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->