### PR TITLE
Document voice upload fields on Create Model

### DIFF
--- a/api-reference/endpoint/model/create-model.mdx
+++ b/api-reference/endpoint/model/create-model.mdx
@@ -11,3 +11,27 @@ iconType: "solid"
   requests. Let your HTTP client set the multipart `Content-Type` boundary
   automatically.
 </Warning>
+
+## Uploading voice files
+
+`type`, `title`, `train_mode`, and `voices` are required. Send each audio file
+as a `voices` form field, repeating the field to upload several clips.
+
+```bash curl
+curl --request POST https://api.fish.audio/model \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --form type=tts \
+  --form train_mode=fast \
+  --form title="My Voice" \
+  --form voices=@a.wav \
+  --form voices=@b.wav
+```
+
+To send your own transcripts, add one `texts` field per clip, in the same order
+as the `voices` fields. Omit `texts` and ASR runs on the uploaded audio instead.
+
+<Note>
+  `samples` is not a request field, so there is nothing to supply for it. It
+  appears only on the model returned by this endpoint, where it defaults to an
+  empty list and holds the preview clips once they exist.
+</Note>


### PR DESCRIPTION
Two separate reports asked how to pass `samples` when creating a model: #40 (`"samples": [], how do I pass it?`) and #41 (`no correct sample parameter was returned. The sample cannot be edited`).

The answer is that `samples` is not a request field at all, and nothing in the page said so. Checked against `https://api.fish.audio/openapi.json` for `POST /model`:

- the request schema has no `samples` property, in any of the four content types it accepts
- `required` is `["type", "title", "train_mode", "voices"]`
- `samples` appears only on the 201 response model, as `{"default": [], "items": {"$ref": "#/components/schemas/SampleEntity"}}`

That empty-list default is what both reporters were looking at in the playground.

The page was only the multipart warning, so this adds the smallest thing that answers the question:

- the four required fields, named
- a `multipart/form-data` example that repeats `voices` for several clips, matching the style already used in `features/voice-cloning.mdx`
- how `texts` maps to the clips, and that ASR runs when it is omitted
- a note that `samples` is response-only

No generated files touched. `api-reference/openapi.json` is deliberately left alone.

Heads up on CI: `check-openapi` fails here because the committed `api-reference/openapi.json` is behind the live schema, which is what #107 updates. It is unrelated to this change.

Closes #40
Closes #41


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for uploading voice files when creating a model.
  * Documented required fields, multipart upload formatting, multiple audio clips, and optional transcripts.
  * Clarified that transcripts may be omitted to enable automatic speech recognition.
  * Explained that `samples` is returned as preview data rather than submitted in the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->