### PR TITLE
docs: fix ASR content-type warning + document WS HTTP/1.1 handshake

### DIFF
--- a/api-reference/asyncapi.yml
+++ b/api-reference/asyncapi.yml
@@ -72,9 +72,6 @@ channels:
       - `Authorization: Bearer <api_key>` - Required for authentication (see security section)
       - `model: <model_name>` - Optional; specifies which TTS model to use (see bindings). Falls back to `s2.1-pro` when omitted or unrecognized
 
-      ## Handshake
-      The WebSocket handshake must be performed over **HTTP/1.1**. HTTP/2 clients are rejected with `400 invalid protocol`, so disable HTTP/2 for the upgrade request (e.g. `curl --http1.1`).
-
 operations:
   receiveText:
     action: receive

--- a/api-reference/asyncapi.yml
+++ b/api-reference/asyncapi.yml
@@ -72,6 +72,9 @@ channels:
       - `Authorization: Bearer <api_key>` - Required for authentication (see security section)
       - `model: <model_name>` - Optional; specifies which TTS model to use (see bindings). Falls back to `s2.1-pro` when omitted or unrecognized
 
+      ## Handshake
+      The WebSocket handshake must be performed over **HTTP/1.1**. HTTP/2 clients are rejected with `400 invalid protocol`, so disable HTTP/2 for the upgrade request (e.g. `curl --http1.1`).
+
 operations:
   receiveText:
     action: receive

--- a/api-reference/endpoint/openapi-v1/speech-to-text.mdx
+++ b/api-reference/endpoint/openapi-v1/speech-to-text.mdx
@@ -7,5 +7,5 @@ iconType: "solid"
 ---
 
 <Warning>
-This BETA endpoint only accepts `multipart/form-data` and `application/msgpack`. It does not accept `application/json` (the audio field cannot be carried as JSON/base64).
+This BETA endpoint only accepts `multipart/form-data` and `application/msgpack`. A JSON body will not work: the `audio` field is raw binary and cannot be sent as a base64 string inside JSON (such requests fail with `HTTP 400`).
 </Warning>

--- a/api-reference/endpoint/openapi-v1/speech-to-text.mdx
+++ b/api-reference/endpoint/openapi-v1/speech-to-text.mdx
@@ -7,5 +7,5 @@ iconType: "solid"
 ---
 
 <Warning>
-This BETA endpoint only accepts `application/form-data` and `application/msgpack`.
+This BETA endpoint only accepts `multipart/form-data` and `application/msgpack`. It does not accept `application/json` (the audio field cannot be carried as JSON/base64).
 </Warning>

--- a/api-reference/endpoint/openapi-v1/speech-to-text.mdx
+++ b/api-reference/endpoint/openapi-v1/speech-to-text.mdx
@@ -7,5 +7,5 @@ iconType: "solid"
 ---
 
 <Warning>
-This BETA endpoint only accepts `multipart/form-data` and `application/msgpack`. A JSON body will not work: the `audio` field is raw binary and cannot be sent as a base64 string inside JSON (such requests fail with `HTTP 400`).
+This BETA endpoint accepts audio only as `multipart/form-data` (a file upload) or `application/msgpack`. JSON is not supported — the audio cannot be sent as a base64 string.
 </Warning>


### PR DESCRIPTION
## What
Two documentation fixes found while helping Vercel build a Fish Audio provider for the AI SDK.

## Changes
- **Speech to Text warning** (`speech-to-text.mdx`): `application/form-data` is not a real MIME type → `multipart/form-data`; also note `application/json` is not usable (the audio field cannot be carried as JSON/base64). Verified: JSON+base64 → `HTTP 400`; `multipart/form-data` → 200.
- **WebSocket TTS** (`asyncapi.yml`): document that the handshake must use **HTTP/1.1** — HTTP/2 upgrade requests are rejected with `400 "invalid protocol"`. Verified live (curl `--http1.1` → `101`; default HTTP/2 → `400 invalid protocol`).

## Note
The `/v1/asr` OpenAPI content-type list itself is corrected in the companion **platform-api** PR (that repo generates `openapi.json`, synced here via `scripts/update-openapi.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788450592&installation_model_id=430858&pr_number=115&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F115&signature=b02098190f23025997c57d36e6b7d88b94eda4e544f234e88f8f4c2ace442b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Speech to Text endpoint guidance to clarify that audio files must be uploaded using `multipart/form-data`.
  * Documented that JSON requests and base64-encoded audio are unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->