### PR TITLE
docs: add Fish Agents platform documentation

### DIFF
--- a/agents/build/client-tools.mdx
+++ b/agents/build/client-tools.mdx
@@ -1,0 +1,139 @@
+---
+title: "Client Tools"
+description: "Let the agent trigger actions in your own app — declared on the agent, executed by your code through the SDK"
+icon: "code"
+---
+
+Client tools run inside your application, not on Fish Audio's servers. You declare the tool on the agent — name, description, parameters — and register a handler in your app with the [Web SDK](/agents/deploy/web-sdk). When the agent decides to call the tool mid-conversation, the SDK invokes your handler and returns its result to the agent.
+
+Use client tools for anything only your frontend can do: navigate to a page, highlight a product, open a modal, read app state, or hand off to a human.
+
+<Note>
+Client tools need code on your side. For tools that call an HTTP endpoint from Fish Audio's side, use [webhook tools](/agents/build/webhook-tools). For built-in capabilities like hanging up, see [system tools](/agents/build/system-tools).
+</Note>
+
+## How it works
+
+<Steps>
+  <Step title="Declare the tool on the agent">
+    Add a tool of type `client` to the agent's tool list, alongside any webhook tools. The name, description, and arguments tell the model what the tool does and when to call it.
+  </Step>
+  <Step title="Register a handler in your app">
+    Pass a handler for the same tool name when starting a session with `@fishaudio/agent-client`.
+  </Step>
+  <Step title="The agent calls the tool">
+    During the conversation, the agent invokes the tool with parameter values. The SDK dispatches the call to your handler.
+  </Step>
+  <Step title="Your result goes back to the agent">
+    The handler's return value is JSON-serialized and sent back, and the agent continues with the result — unless the tool is fire-and-forget.
+  </Step>
+</Steps>
+
+## Declare a client tool
+
+Client tools sit alongside webhook tools in the agent's tool list. A declaration looks like this:
+
+```json Tool definition
+{
+  "tool_type": "client",
+  "name": "highlight_product",
+  "description": "Visually highlight a product on the page the user is viewing.",
+  "arguments": [
+    { "name": "product_id", "description": "ID of the product to highlight." }
+  ],
+  "expects_response": true
+}
+```
+
+| Field | Description |
+|---|---|
+| `name` | How the model refers to the tool — must match the name you register in the SDK exactly |
+| `description` | Tells the model what the tool does and when to use it |
+| `arguments` | Named inputs the model fills in; delivered to your handler as one JSON object |
+| `expects_response` | Whether the agent waits for your handler's return value before continuing |
+
+### Naming rules
+
+Tool names must match `^[a-zA-Z][a-zA-Z0-9_-]{0,63}$` — start with a letter, then letters, digits, underscores, or hyphens, up to 64 characters total.
+
+- Built-in tools live under a leading underscore (like `_transfer_call`), which the pattern makes unreachable — your names never collide with them.
+- Names must be unique per agent — declaring a duplicate fails with a `400`.
+
+## Handle the call in your app
+
+Register handlers with the `clientTools` option when starting a session, or later with `registerClientTool`:
+
+<CodeGroup>
+```javascript At session start
+import { AgentSession } from "@fishaudio/agent-client";
+
+const session = await AgentSession.start({
+  agentId: "YOUR_AGENT_ID",
+  clientTools: {
+    highlight_product: async (params) => {
+      const el = document.getElementById(String(params.product_id));
+      el?.scrollIntoView({ behavior: "smooth" });
+      el?.classList.add("highlighted");
+      return { highlighted: true };
+    },
+  },
+});
+```
+
+```javascript After session start
+session.registerClientTool("open_page", (params, { callId, toolName }) => {
+  window.location.assign(`/products/${String(params.product_id)}`);
+});
+```
+</CodeGroup>
+
+A handler receives the parameter values as a single object, plus a context object with `callId` and `toolName`. It can be synchronous or async:
+
+```typescript Handler signature
+type ClientToolHandler = (
+  params: Record<string, unknown>,
+  ctx: { callId: string; toolName: string },
+) => unknown | Promise<unknown>;
+```
+
+<Tip>
+Parameter values are produced by the model. Validate them in your handler before acting on them, just as you would any external input.
+</Tip>
+
+### What the agent receives
+
+| Handler outcome | Result |
+|---|---|
+| Returns a value | JSON-serialized and sent back to the agent |
+| Throws | An error result is sent back; the SDK emits an `error` event with code `tool_failed` |
+| Exceeds the timeout (default 15 s) | An error result is sent back automatically; code `tool_timeout` |
+| Tool called but no handler registered | An error result is sent back automatically |
+
+The agent is never left hanging: while `expects_response` is `true` the agent suspends that tool call until your result arrives or the timeout fires, then continues either way. Errors and timeouts return to the model as tool errors, so the agent can recover in conversation ("I couldn't open that page — let me try something else"). To change the handler timeout, pass `clientToolTimeoutMs` (in milliseconds) when starting the session. Note there is a second, server-side deadline: the agent stops waiting after the tool's `timeout_seconds` (default 30 s, settable 1–120 on the tool), and a handler result arriving after that is ignored — so `clientToolTimeoutMs` can only tighten the client-side deadline, not extend the agent's wait.
+
+## Fire-and-forget tools
+
+Set `expects_response` to `false` for tools that are pure side effects — the agent triggers your handler and keeps talking without waiting. Any return value is ignored.
+
+This suits UI actions where confirmation adds nothing: scrolling, opening a panel, firing an analytics event. If the agent should react to the outcome ("the page is open, now walk the user through it"), keep `expects_response: true`.
+
+## Observe tool activity
+
+Every tool call — client and webhook alike — emits `toolCallStarted`, `toolCallCompleted`, and `toolCallFailed` events on the session, with the call ID, tool name, and payloads. The events are on by default; sessions created with `tool_events: false` don't emit them. Use them to render tool activity in your UI. See the [Web SDK](/agents/deploy/web-sdk) for the event reference.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
+    Full `@fishaudio/agent-client` API: sessions, events, audio.
+  </Card>
+  <Card title="Webhook tools" icon="webhook" href="/agents/build/webhook-tools">
+    Tools that call your HTTP endpoints server-side.
+  </Card>
+  <Card title="System tools" icon="gears" href="/agents/build/system-tools">
+    Built-in capabilities you toggle per agent.
+  </Card>
+  <Card title="Tools overview" icon="screwdriver-wrench" href="/agents/build/tools">
+    How the agent chooses and combines tools.
+  </Card>
+</CardGroup>

--- a/agents/build/configuration.mdx
+++ b/agents/build/configuration.mdx
@@ -1,0 +1,157 @@
+---
+title: "Configuration"
+description: "Set your agent's system prompt, first message, and conversation behavior — in the Builder or through the API"
+icon: "sliders"
+---
+
+Configuration is the Builder's home tab: define how your agent behaves, how it opens each conversation, and how it paces its turns. Every edit is saved to the agent's **draft** automatically — callers only hear your changes after you [publish](/agents/deploy/versions-publishing). New to Agents? Start with the [Quickstart](/agents/quickstart).
+
+## System prompt
+
+The system prompt sets the personality, goals, and guardrails that steer every reply. It is capped at **4,000 characters** — the Builder stops input at the limit, and the API rejects longer prompts with `422 Unprocessable Entity`.
+
+<Tip>
+Keep the prompt focused:
+
+- State who the agent is and what it should accomplish, in a few sentences each.
+- Spell out guardrails explicitly ("If asked about pricing, direct the caller to sales").
+- Write for the ear — replies are spoken aloud, so ask for short, conversational answers.
+</Tip>
+
+## First message
+
+Choose how the agent opens each conversation:
+
+| Mode | Behavior | Field on the wire |
+|---|---|---|
+| **Off** | The agent stays silent and waits for the caller to speak first. | — |
+| **Fixed message** | The agent opens with the exact text you provide, every time. | `first_message` |
+| **Prompt** | The agent generates its opening line from instructions you provide. | `first_message_prompt` |
+
+`first_message` and `first_message_prompt` can each hold up to 10,000 characters. The active mode (`first_message_mode`: `off`, `fixed`, or `prompt`) decides what callers hear.
+
+## Voice
+
+The Voice panel selects the voice profile your agent speaks with (`voice_profile_id`) and its speaking language (`speaking_language`: `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`). See [Voice & language](/agents/build/voice-language) for picking a voice and how automatic language detection interacts with this setting.
+
+## Conversation settings
+
+### Turn-taking
+
+`conversation.eagerness` controls how quickly the agent starts talking after the caller stops:
+
+- `relaxed` — waits longer, never talks over the caller.
+- `balanced` (default) — waits for a natural pause.
+- `eager` — jumps in quickly.
+
+### Interruptions
+
+- `conversation.interruptible` (default `true`) — whether the caller can barge in while the agent is speaking.
+- `conversation.interruption_sensitivity` — how much caller speech counts as an interruption:
+  - `low` — the agent stops less readily, talking through background noise and short acknowledgements.
+  - `balanced` (default) — interrupts on normal speech.
+  - `high` — the agent stops more readily when the caller speaks, even on brief utterances.
+
+### Call duration
+
+`conversation.max_duration_seconds` (60–3600, default `1800`) ends the session automatically when the limit is reached.
+
+<Note>
+[Preview calls](/agents/test/preview-calls) in the Builder are capped at 10 minutes or this setting, whichever is lower.
+</Note>
+
+### Recording
+
+`conversation.record_audio` (default `true`) — store per-speaker audio for [playback and download](/agents/monitor/conversation-history#what-gets-stored), with a per-session override on the [session request](/agents/deploy/authentication). In the console this lives under your agent's **Settings**. Recording defaults to on — make sure callers are informed and consent where your jurisdiction requires it.
+
+### Timezone
+
+`conversation.timezone` is the default IANA timezone (like `Asia/Shanghai`) the agent uses for dates and times in conversation. Leave it empty for **automatic** — each session follows the caller's device or phone number, falling back to UTC. Set one when your agent serves a single region regardless of who calls. A per-session `timezone` on the [session request](/agents/build/time-timezone) overrides this. See [Time & timezone](/agents/build/time-timezone) for the full resolution order.
+
+## Autosave and publishing
+
+There is no Save button. Each change is written to the agent's draft moments after you stop editing, and the **Saving… / Saved** indicator at the bottom-left of the page shows the current state. If a save fails, the Builder tells you and keeps your pending edits so nothing is lost.
+
+Drafts never affect live traffic: active integrations keep using the last published version until you press **Publish**, which snapshots the draft as a new immutable version. The Publish button lights up whenever the draft differs from what is published. See [Versions & publishing](/agents/deploy/versions-publishing).
+
+## Configure through the API
+
+The same draft is readable and writable over REST — useful for provisioning agents from your own systems.
+
+### Read the draft
+
+<CodeGroup>
+```bash Request
+curl --request GET "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+```json Response (abridged)
+{
+  "config_hash": "sha256:5f2c1a9e…",
+  "prompt": {
+    "system_prompt": "You are Aria, a friendly support agent for Acme…",
+    "first_message_mode": "fixed",
+    "first_message": "Hi, thanks for calling Acme. How can I help?"
+  },
+  "voice": {
+    "voice_profile_id": "802e3bc2b27e49c2995d23ef70e6ac89",
+    "speaking_language": "en"
+  },
+  "conversation": {
+    "max_duration_seconds": 1800,
+    "eagerness": "balanced",
+    "interruptible": true,
+    "interruption_sensitivity": "balanced",
+    "timezone": ""
+  }
+}
+```
+</CodeGroup>
+
+The response also includes the `tools`, `knowledge_base`, `analysis`, and `webhooks` sections, each covered on its own page. `config_hash` identifies this draft revision — it changes whenever an edit changes the draft's content, and a mismatch with the published version is what marks an agent as having unpublished changes.
+
+### Update sections
+
+`PATCH` takes a partial body and deep-merges it into the draft: send only the sections and fields you want to change, and everything else keeps its value. Fields that hold a list — `webhooks.post_call` among them — are replaced as a whole, so send the complete list whenever you change one.
+
+```bash
+curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "prompt": { "system_prompt": "You are Aria, a concise support agent for Acme." },
+    "conversation": { "eagerness": "relaxed" }
+  }'
+```
+
+The response includes the draft's new `config_hash`. Values outside the documented limits — a system prompt over 4,000 characters, `max_duration_seconds` outside 60–3600 — are rejected with `422 Unprocessable Entity` and the draft is left unchanged.
+
+### Config sections
+
+| Section | What it holds | Documented in |
+|---|---|---|
+| `prompt` | System prompt and first-message settings | This page |
+| `voice` | Voice profile and speaking language | [Voice & language](/agents/build/voice-language) |
+| `conversation` | Call duration, turn-taking, interruption behavior, timezone, and storage | This page; storage in [Conversation history](/agents/monitor/conversation-history#what-gets-stored) |
+| `tools` | Attached webhook tools and system tool switches | [Tools](/agents/build/tools) |
+| `knowledge_base` | Attached knowledge sources | [Knowledge base](/agents/build/knowledge-base) |
+| `analysis` | Post-call summary, data fields, and success criteria | [Post-call analysis](/agents/monitor/post-call-analysis) |
+| `webhooks` | Post-call webhook delivery | [Webhooks](/agents/monitor/webhooks) |
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Voice & language" icon="waveform-lines" href="/agents/build/voice-language">
+    Choose a voice profile and control the speaking language.
+  </Card>
+  <Card title="Versions & publishing" icon="code-branch" href="/agents/deploy/versions-publishing">
+    Turn the draft into an immutable live version.
+  </Card>
+  <Card title="Preview calls" icon="phone" href="/agents/test/preview-calls">
+    Talk to your draft in the Builder before publishing.
+  </Card>
+  <Card title="Tools" icon="wrench" href="/agents/build/tools">
+    Let the agent call your backend mid-conversation.
+  </Card>
+</CardGroup>

--- a/agents/build/dynamic-variables.mdx
+++ b/agents/build/dynamic-variables.mdx
@@ -1,0 +1,155 @@
+---
+title: "Dynamic Variables & Overrides"
+description: "Personalize each session with template variables and per-session configuration overrides"
+icon: "brackets-curly"
+---
+
+An agent's published configuration is shared by every caller — but each session can be personalized at creation time. Two mechanisms cover this, and both travel in the same `POST /v1/agent/sessions` request:
+
+| Mechanism | What it does | Gated by |
+|---|---|---|
+| `dynamic_variables` | Fills `{{placeholder}}` templates in your configuration text | Nothing per-agent — no allowlist |
+| `overrides` | Replaces whole configuration fields for this session | Per-agent allowlist of overridable fields |
+
+## Dynamic variables
+
+Write `{{variable_name}}` placeholders in your agent's system prompt or first message and supply values when you create the session. Substitution happens once, when the published configuration is assembled for the session.
+
+```text System prompt
+You are a support agent for {{company}}. The caller's name is {{customer_name}}
+and they are on the {{plan}} plan. Greet them by name.
+```
+
+Pass values as a flat object of strings, numbers, or booleans. Variable names must match `[A-Za-z][A-Za-z0-9_]*` (no hyphens or dots), string values are capped at 1,000 characters, and a request can carry at most 50 variables — violations reject session creation with `422`:
+
+<CodeGroup>
+```bash API (curl)
+curl --request POST https://api.fish.audio/v1/agent/sessions \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "agent_id": "YOUR_AGENT_ID",
+    "dynamic_variables": {
+      "company": "Acme",
+      "customer_name": "Ada",
+      "plan": "Pro"
+    }
+  }'
+```
+
+```javascript JavaScript SDK
+import { AgentSession } from "@fishaudio/agent-client";
+
+// Public agent: the SDK creates the session and sends the variables for you.
+const session = await AgentSession.start({
+  agentId: "YOUR_AGENT_ID",
+  dynamicVariables: { company: "Acme", customer_name: "Ada", plan: "Pro" },
+});
+```
+</CodeGroup>
+
+<Warning>
+Placeholders with no matching variable are **not** removed — the literal `{{variable_name}}` text stays in the prompt, visible to the model. Make sure every placeholder in your configuration has a value at session creation.
+</Warning>
+
+<Note>
+Session records never store dynamic variable values.
+</Note>
+
+<Tip>
+You don't need a variable for the current date or time — the agent already knows both, in the session's timezone. See [Time & timezone](/agents/build/time-timezone).
+</Tip>
+
+## Overrides
+
+Overrides replace configuration fields wholesale for one session — for example, forcing a different language for a caller. Because they change agent behavior, each agent declares which fields callers may override; everything else is rejected.
+
+<CodeGroup>
+```bash API (curl)
+curl --request POST https://api.fish.audio/v1/agent/sessions \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "agent_id": "YOUR_AGENT_ID",
+    "overrides": { "language": "ja" }
+  }'
+```
+
+```javascript JavaScript SDK
+import { AgentSession } from "@fishaudio/agent-client";
+
+const session = await AgentSession.start({
+  agentId: "YOUR_AGENT_ID",
+  overrides: { language: "ja" },
+});
+```
+</CodeGroup>
+
+### The `language` shorthand
+
+Overriding the session language is common enough that the request accepts a top-level `language` field as shorthand for `overrides.language`. Both forms pass through the same allowlist gate — if `language` is not overridable on the agent, both are rejected.
+
+```json
+{ "agent_id": "YOUR_AGENT_ID", "language": "ja" }
+```
+
+### Validation
+
+| Case | Result |
+|---|---|
+| Override field not on the agent's allowlist | `400` |
+| Unknown field inside `overrides` | `422` |
+| Unknown top-level field in the request | `422` |
+
+<Note>
+The session record stores which overrides took effect.
+</Note>
+
+## Who supplies the values
+
+Where variables and overrides come from depends on how the session is [authenticated](/agents/deploy/authentication):
+
+| Mode | Who creates the session | Who supplies variables and overrides |
+|---|---|---|
+| `agentId` ([public agents](/agents/deploy/public-agents)) | The SDK, directly from the browser | The browser, via `AgentSession.start()` options |
+| `sessionToken` (private agents) | Your backend, with your API key | Your backend, in its `POST /v1/agent/sessions` call |
+
+In `sessionToken` mode the SDK's `overrides`, `dynamicVariables`, and `language` options have no effect — the session already exists by the time the token reaches the browser. Attach personalization server-side instead:
+
+```javascript Backend (sessionToken mode)
+// Your backend endpoint, called by your own frontend
+const response = await fetch("https://api.fish.audio/v1/agent/sessions", {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.FISH_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    agent_id: "YOUR_AGENT_ID",
+    dynamic_variables: { customer_name: user.name, plan: user.plan },
+    overrides: { language: user.locale },
+  }),
+});
+const sessionToken = await response.json(); // pass to AgentSession.start({ sessionToken })
+```
+
+<Tip>
+In `agentId` mode, values arrive from the end user's browser — treat them as untrusted input. Keep the override allowlist limited to fields you are comfortable letting anyone set, and use `sessionToken` mode when personalization must come from data only your backend knows.
+</Tip>
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Agent configuration" icon="sliders" href="/agents/build/configuration">
+    The fields your placeholders and overrides act on.
+  </Card>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    API keys, session tokens, and the two session modes.
+  </Card>
+  <Card title="Versions & publishing" icon="code-branch" href="/agents/deploy/versions-publishing">
+    Sessions assemble the published configuration.
+  </Card>
+  <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
+    Every `AgentSession.start()` option.
+  </Card>
+</CardGroup>

--- a/agents/build/knowledge-base.mdx
+++ b/agents/build/knowledge-base.mdx
@@ -1,0 +1,129 @@
+---
+title: "Knowledge Base"
+description: "Ground your agent in your own documents — add a source once, attach it to any agent in your workspace"
+icon: "book"
+---
+
+The knowledge base is a workspace-wide document library. Add a source once — an uploaded Markdown or plain-text file — and attach it to any number of agents. In conversation, the agent draws on attached sources to answer questions its [instructions](/agents/build/configuration) alone can't cover: product details, policies, FAQs, procedures.
+
+## Add sources
+
+Sources come in two scopes:
+
+- **Workspace sources** live in the shared library. Add them from the workspace-level **Knowledge base** page with **Add file** — choose a `.md` or `.txt` file (UTF-8 text, up to 1 MB) and give the source a name and an optional description. Workspace sources can be attached to any number of agents.
+- **Agent-private sources** belong to a single agent. On your agent's **Knowledge base** tab, **New private file** creates a source that is attached to that agent immediately. It doesn't appear in the shared library, can't be attached to other agents, and is not listed by the [knowledge-sources API](#manage-sources-over-the-api).
+
+To attach a shared source to an agent, open the agent's **Knowledge base** tab and click **Import from global knowledge base**.
+
+Every source is plain text and stays editable after upload: open a source to view its content and edit the text in place — you never re-upload a file to make a change.
+
+<Note>
+PDF, Office, and scanned documents are not supported. Convert them to Markdown or plain text first.
+</Note>
+
+### Upload validation
+
+Files are validated, parsed, and indexed as part of the upload itself — there is no background processing to wait for. When the upload succeeds, the source is immediately available to attached agents. If the file is empty, over 1 MB, or not UTF-8 text, the upload is rejected with an error and nothing is created — fix the file and try again.
+
+### Folders
+
+Group sources into folders with **New folder**, and rename sources from the row menu. Deleting a folder never deletes its sources — anything inside moves back to **All sources**.
+
+## Share sources across agents
+
+Workspace sources belong to the workspace, not to a single agent (agent-private files offer only **Edit** and **Delete**). In the library, the **Used by** column shows how many agents attach each source, and **Manage access** lists every agent with a toggle:
+
+- **Attach** — turn an agent on to give it access to the source.
+- **Detach** — turn an agent off. The source stays in the library and remains attached to other agents.
+
+Editing a source propagates to every agent that attaches it — you never update agents one by one. Each attached agent shows the edit as an unpublished draft change.
+
+<Warning>
+**Delete** removes a source from *all* agents that reference it, not just the one you're editing. To remove a source from a single agent, detach it with **Manage access** instead.
+</Warning>
+
+## How your agent uses knowledge
+
+### Small corpora are inlined
+
+If the total size of an agent's attached sources is **8 KB or less**, the full content is inlined into the agent's instructions. This is the fastest path: the agent has everything up front, with zero per-turn lookup cost.
+
+<Note>
+Inlined knowledge produces no retrieval events. If your corpus is small and you don't see retrieval activity, nothing is wrong — the content is already in the prompt.
+</Note>
+
+### Larger corpora are searched per turn
+
+Above 8 KB, the agent searches attached sources on every turn, using the user's latest message as the query, and injects the best-matching passages into that turn's context. The search runs under a fixed time budget: if it can't complete in time, the turn is answered without retrieved context. Retrieval never delays the agent's reply.
+
+### Publishing pins revisions
+
+When you [publish](/agents/deploy/versions-publishing) an agent, the published version pins the then-current revision of every attached source. Sessions read the pinned revisions, so edits you make mid-call never leak into an in-progress conversation. Publish again to roll updated content out.
+
+## Limits
+
+| Limit | Value |
+|---|---|
+| File upload formats | `.md`, `.txt` |
+| File size | 1 MB per file |
+| Sources per agent | 100 |
+| Inline threshold | 8 KB total attached content |
+
+Attaching more than 100 sources to one agent is rejected with `422`.
+
+## Manage sources over the API
+
+Knowledge sources are exposed at `/v1/agent/knowledge-sources`. Only workspace sources appear on this surface — agent-private files are a console-only convenience:
+
+| Endpoint | Description |
+|---|---|
+| `GET /v1/agent/knowledge-sources` | List sources in your workspace |
+| `POST /v1/agent/knowledge-sources` | Create a source — multipart upload with the `.md`/`.txt` file in the `source` field |
+| `GET /v1/agent/knowledge-sources/{source_id}` | Retrieve a source |
+| `PATCH /v1/agent/knowledge-sources/{source_id}` | Rename a source or replace its content — multipart like create; omitted fields keep their values, and a new `source` file bumps `revision_number` |
+| `DELETE /v1/agent/knowledge-sources/{source_id}` | Delete a source |
+| `GET /v1/agent/knowledge-sources/{source_id}/agents` | List agents that attach the source |
+
+<CodeGroup>
+```bash Create a source
+curl --request POST https://api.fish.audio/v1/agent/knowledge-sources \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --form "source=@faq.md;type=text/markdown" \
+  --form "name=Customer FAQ" \
+  --form "description=Answers for the support agent"
+```
+
+```bash Replace content
+curl --request PATCH https://api.fish.audio/v1/agent/knowledge-sources/{source_id} \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --form "source=@faq-v2.md;type=text/markdown"
+```
+
+```bash Check dependents
+curl https://api.fish.audio/v1/agent/knowledge-sources/{source_id}/agents \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+</CodeGroup>
+
+Only the `source` file part is required on create — `name` falls back to the uploaded file's name.
+
+<Note>
+`DELETE` returns `409` while the source is still attached to any agent — in its draft or its published version. Call the dependents endpoint to see which agents use it, then detach it from each — remove its id from `knowledge_base.knowledge_source_ids` in an agent update — and republish any agent whose published version still references it. Deleting from the console instead removes the source from all agents at once, after a confirmation.
+</Note>
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Agent configuration" icon="sliders" href="/agents/build/configuration">
+    Instructions, voice, and everything else your agent is made of.
+  </Card>
+  <Card title="Versions & publishing" icon="code-branch" href="/agents/deploy/versions-publishing">
+    How publishing snapshots your agent — knowledge revisions included.
+  </Card>
+  <Card title="Preview calls" icon="phone" href="/agents/test/preview-calls">
+    Talk to your draft and check knowledge answers before publishing.
+  </Card>
+  <Card title="Conversation history" icon="clock-rotate-left" href="/agents/monitor/conversation-history">
+    Review transcripts of past sessions.
+  </Card>
+</CardGroup>

--- a/agents/build/system-tools.mdx
+++ b/agents/build/system-tools.mdx
@@ -1,0 +1,46 @@
+---
+title: "System Tools"
+description: "Built-in agent capabilities — language detection, hang up call, and call transfer — enabled per agent"
+icon: "toggle-on"
+---
+
+System tools are capabilities built into the platform. There is nothing to create or host — each agent simply enables the ones it needs.
+
+| Tool | Key | What it does |
+|---|---|---|
+| Language detection | `language_detection` | Lets the agent detect the language the user is speaking. |
+| Hang up call | `hang_up_call` | Lets the agent end the call itself. |
+| Transfer call | `transfer_call` | Lets the agent hand a live phone call to another number. |
+
+<Note>
+Unlike [webhook tools](/agents/build/webhook-tools), system tools are not workspace resources shared across agents. The on/off state is stored per agent — toggling a system tool on one agent never affects another.
+</Note>
+
+## Toggle in the Builder
+
+Open your agent's **Tools** page in the Builder. The **System tools** card holds the **Hang up call** switch. The **Language detection** switch lives on the agent's **Configuration** page, next to **Speaking language** — see [Voice & language](/agents/build/voice-language). Flip a switch to enable or disable that capability for this agent.
+
+## Toggle via the API
+
+Over the REST API, system tool switches are part of the agent's configuration, in the same `tools` section that holds its attached webhook tools. See [Configuration](/agents/build/configuration) for reading and updating an agent's config.
+
+## Transfer call
+
+`transfer_call` has no switch of its own: it is enabled automatically once the agent has a transfer destination configured, and only on phone sessions — web sessions have no call to transfer. See [Transfers](/agents/telephony/transfers) for configuring destinations and everything else about transfers.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Tools overview" icon="wrench" href="/agents/build/tools">
+    How webhook, client, and system tools fit together.
+  </Card>
+  <Card title="Webhook tools" icon="webhook" href="/agents/build/webhook-tools">
+    Call your own HTTP endpoints from a conversation.
+  </Card>
+  <Card title="Client tools" icon="browser" href="/agents/build/client-tools">
+    Run tool calls inside your own app via the SDK.
+  </Card>
+  <Card title="Voice & language" icon="language" href="/agents/build/voice-language">
+    Configure the agent's voice and speaking language.
+  </Card>
+</CardGroup>

--- a/agents/build/time-timezone.mdx
+++ b/agents/build/time-timezone.mdx
@@ -1,0 +1,98 @@
+---
+title: "Time & Timezone"
+description: "Your agent knows the current date and time by default — how the timezone is chosen and how to opt out"
+icon: "clock"
+---
+
+Agents are time-aware out of the box: every session knows today's date and the current time in the session's timezone. You don't reference a variable or add anything to your prompt — "tomorrow morning" and "next Tuesday" ground correctly from the first turn, on every channel (voice, text, and phone).
+
+## What the agent knows
+
+Fish Audio injects two pieces of world context server-side:
+
+| When | What | Example |
+| ------------------ | ---------------------------- | ------------------------------------------------------------------ |
+| At session start | Today's date and the session timezone | `Today is Thursday, July 23, 2026. Session timezone: Asia/Shanghai (UTC+8).` |
+| Before every reply | The current time, minute precision | `Current date and time: Thursday, July 23, 2026 at 13:00 (Asia/Shanghai).` |
+
+The time is refreshed on every turn, so it stays accurate through long conversations and past midnight — it never freezes at the session's start time.
+
+<Note>
+  Injection happens outside your configuration, so it never counts toward the
+  system prompt's character limit.
+</Note>
+
+## Which timezone a session uses
+
+The timezone is resolved once, when the session is created, taking the first that applies:
+
+1. **`timezone`** in the creation request — your explicit per-session choice, as an IANA name like `Asia/Shanghai`. An invalid name rejects the request with `422`.
+2. **The agent's configured timezone** — set on the agent in the Builder (**Configuration → Timezone**) or via the [agent config API](/agents/build/configuration). Pin one when your agent serves a single region regardless of who calls.
+3. **`client_timezone`** — a hint with the end user's browser timezone, sent automatically by the [Web SDK](/agents/deploy/web-sdk) in public-agent mode. Used only when neither of the above is set; an invalid hint is ignored rather than failing the session.
+4. **The caller's phone number** — inbound calls infer the timezone from the caller's country when that country has a single timezone.
+5. **UTC** otherwise.
+
+In the browser, this means zero configuration: the SDK detects the visitor's real timezone and the agent talks about "today" in the user's local terms, not yours.
+
+With [session token](/agents/deploy/authentication) auth, the SDK's automatic hint doesn't apply — your backend creates the session, so set `timezone` (or forward the browser's value as `client_timezone`) in the creation request:
+
+```bash API (curl)
+curl --request POST https://api.fish.audio/v1/agent/sessions \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "agent_id": "YOUR_AGENT_ID",
+    "timezone": "Asia/Shanghai"
+  }'
+```
+
+<Note>
+  Phone-number inference is country-level only. Countries that span several
+  timezones (the US, Canada, Australia, Russia, Brazil) are skipped — set the
+  agent's timezone for those. Calls that resolve nothing run in UTC.
+</Note>
+
+## Turn it off
+
+Time awareness is on by default. To withhold both the date and the per-turn time from a session — for example a role-play agent set on a fictional date, or a test that must be reproducible — set `world_context: false` when creating the session:
+
+<CodeGroup>
+```bash API (curl)
+curl --request POST https://api.fish.audio/v1/agent/sessions \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "agent_id": "YOUR_AGENT_ID",
+    "world_context": false
+  }'
+```
+
+```javascript JavaScript SDK
+import { AgentSession } from "@fishaudio/agent-client";
+
+// Public agent: the SDK forwards the opt-out in its creation request.
+const session = await AgentSession.start({
+  agentId: "YOUR_AGENT_ID",
+  worldContext: false,
+});
+```
+</CodeGroup>
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card
+    title="Authentication"
+    icon="key"
+    href="/agents/deploy/authentication"
+  >
+    All session-creation parameters, including `timezone` and `world_context`.
+  </Card>
+  <Card
+    title="Dynamic variables"
+    icon="brackets-curly"
+    href="/agents/build/dynamic-variables"
+  >
+    Personalize the rest of the prompt at session creation.
+  </Card>
+</CardGroup>

--- a/agents/build/tools.mdx
+++ b/agents/build/tools.mdx
@@ -1,0 +1,108 @@
+---
+title: "Tools"
+description: "Give your agent the ability to act during a conversation — call your backend, trigger actions in your app, or use built-in capabilities"
+icon: "wrench"
+---
+
+Out of the box, an agent can only talk. Tools let it act: fetch an order status mid-call, open a page in your app, or hang up when the conversation is over. You describe what a tool does and what arguments it takes; the agent decides when to call it.
+
+<CardGroup cols={3}>
+  <Card title="Webhook tools" icon="globe" href="/agents/build/webhook-tools">
+    The platform calls your HTTP endpoint and speaks the result.
+  </Card>
+  <Card title="Client tools" icon="code" href="/agents/build/client-tools">
+    Your application executes the tool through the SDK.
+  </Card>
+  <Card title="System tools" icon="toggle-on" href="/agents/build/system-tools">
+    Built-in capabilities you switch on per agent.
+  </Card>
+</CardGroup>
+
+## Choose a tool type
+
+| Type | Executed by | Use it for |
+|---|---|---|
+| [Webhook](/agents/build/webhook-tools) | Fish Audio — we call your HTTP endpoint during the conversation | Order lookups, CRM reads, bookings — anything your backend can answer |
+| [Client](/agents/build/client-tools) | Your app — the SDK hands the call to code you register | Navigation, UI updates, device actions — anything only the client can do |
+| [System](/agents/build/system-tools) | The platform — no code involved | Language detection, hanging up the call |
+
+Webhook and client tools are **custom tools**: you define a name, a description, and arguments, and the agent fills in the argument values when it calls. System tools are ready-made — enable them with a switch on each agent.
+
+## Where tools live
+
+Custom tools are **workspace resources**, not part of a single agent. Define a `lookup_order` tool once and attach it to your support, sales, and after-hours agents. You manage them in two places:
+
+- **Builder → Tools** shows the tools attached to the agent you are editing, plus that agent's system-tool switches. Tools you create here are attached to the agent immediately.
+- **The workspace tool library** lists every custom tool with how many agents use it. Tools you create here start unattached — grant agents access afterwards.
+
+<Note>
+Editing a shared tool updates the draft of **every** agent that uses it. Those agents show unpublished changes until they are published again — see [Versions & publishing](/agents/deploy/versions-publishing).
+</Note>
+
+## Detach vs. delete
+
+- **Detach** is agent-scoped. Removing a tool from an agent in the Builder leaves the tool — and its other attachments — untouched.
+- **Delete** is workspace-wide. Deleting a tool from the library in the console detaches it from every agent that uses it, and those agents show unpublished changes.
+
+Over the API, `DELETE` is stricter: it returns `409` while the tool is still attached to any agent. List the tool's dependent agents first and detach it from each one.
+
+## Manage tools over the API
+
+Every endpoint requires your API key — see [Authentication](/agents/deploy/authentication).
+
+| Endpoint | Description |
+|---|---|
+| `GET /v1/agent/tools` | List the custom tools in your workspace |
+| `POST /v1/agent/tools` | Create a tool — starts unattached |
+| `GET /v1/agent/tools/{tool_id}` | Retrieve a tool's configuration |
+| `PATCH /v1/agent/tools/{tool_id}` | Update a tool — every field is optional |
+| `DELETE /v1/agent/tools/{tool_id}` | Delete a tool — returns `409` while any agent still uses it |
+| `GET /v1/agent/tools/{tool_id}/agents` | List the agents that use this tool |
+
+Create a webhook tool:
+
+```bash
+curl --request POST https://api.fish.audio/v1/agent/tools \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "tool_type": "webhook",
+    "name": "lookup_order",
+    "description": "Look up the status of a customer order.",
+    "arguments": [
+      { "name": "order_number", "description": "The order number the caller provides." }
+    ],
+    "method": "GET",
+    "url": "https://api.example.com/orders/{{order_number}}",
+    "timeout_seconds": 10
+  }'
+```
+
+Arguments can be referenced anywhere in the request with `{{name}}` placeholders. Before deleting a tool, check which agents depend on it:
+
+```bash
+curl https://api.fish.audio/v1/agent/tools/{tool_id}/agents \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+The response lists each dependent agent's `agent_id` and `name`, plus a
+`total` count.
+
+Field-level configuration — custom headers, request body templates, timeouts, error handling, and mock responses — is covered in [Webhook tools](/agents/build/webhook-tools).
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Test it live" icon="phone" href="/agents/test/preview-calls">
+    Call your draft agent before publishing.
+  </Card>
+  <Card title="Versions & publishing" icon="code-branch" href="/agents/deploy/versions-publishing">
+    Drafts, published versions, and what "unpublished changes" means.
+  </Card>
+  <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
+    Register client tool handlers in your application.
+  </Card>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    API keys for the endpoints above.
+  </Card>
+</CardGroup>

--- a/agents/build/voice-language.mdx
+++ b/agents/build/voice-language.mdx
@@ -1,0 +1,98 @@
+---
+title: "Voice & Language"
+description: "Choose the voice your agent speaks with and the language it converses in"
+icon: "microphone"
+---
+
+Your agent speaks with a voice model from the Fish Audio Voice Library — the same voices you use for text to speech. Pick one in the Builder, or set it through the API, and choose the language the agent holds conversations in.
+
+<CardGroup cols={3}>
+  <Card title="Configuration page" icon="sliders" href="/agents/build/configuration">
+    Where the voice and language settings live in the Builder.
+  </Card>
+  <Card title="Voice Library" icon="book-open" href="/features/manage-voices">
+    Browse public voices and manage your own.
+  </Card>
+  <Card title="Voice Cloning" icon="clone">
+    Create a custom voice, then use it here. See [Voice Cloning](/features/voice-cloning).
+  </Card>
+</CardGroup>
+
+## Pick a voice in the Builder
+
+The voice picker on the **Configuration** page has two levels: a curated list for a fast start, and the full Voice Library when you want something specific.
+
+<Steps>
+  <Step title="Open the voice selector">
+    In your agent's **Configuration** page, open the voice card. The **Choose a voice** view shows a curated selection of voices.
+  </Step>
+  <Step title="Browse the full library (optional)">
+    Not seeing the right fit? Select **More voices** to open the **Select Voice** browser — the full Voice Library, with your own cloned voices under **My Voices**.
+  </Step>
+  <Step title="Save automatically">
+    Your selection is written to the agent's draft configuration as soon as you pick it — there is no Save button. Start a [preview call](/agents/test/preview-calls) to hear the voice in a real conversation.
+  </Step>
+  <Step title="Publish">
+    Draft changes don't affect live sessions until you **Publish**. See [Versions & publishing](/agents/deploy/versions-publishing).
+  </Step>
+</Steps>
+
+## Use any voice model
+
+The agent's voice is a **voice model id** (`voice_profile_id`) — the same ids used as `reference_id` in [Text to Speech](/features/text-to-speech). Any public voice model from the Voice Library works, including:
+
+- **Library voices** — ready-made public voices. Find ids in the [Voice Library](/features/manage-voices).
+- **Your cloned voices** — [clone a voice](/features/voice-cloning) once, then use its model id as your agent's voice.
+
+## Set the voice via API
+
+Voice settings live in the `voice` section of the agent's configuration. Patches are partial — only the fields you send change, and the result is saved to the draft:
+
+<CodeGroup>
+```bash API (curl)
+curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "voice": {
+      "voice_profile_id": "802e3bc2b27e49c2995d23ef70e6ac89"
+    }
+  }'
+```
+</CodeGroup>
+
+`voice.speaking_language` lives in the same section and is patched the same way. As in the Builder, API edits land in the draft — publish to roll them out.
+
+## Speaking language
+
+**Speaking language** sets the default language for the agent's conversations — one of `en`, `ja`, `zh`, `ko`, `es`, `fr`, or `de` (`voice.speaking_language` on the wire). Whether it is pinned or just a fallback depends on the **Language detection** [system tool](/agents/build/system-tools):
+
+| Language detection | Session behavior |
+|---|---|
+| On | The session runs in automatic language mode — the agent follows the language the caller actually speaks. |
+| Off (default) | Every session uses the configured speaking language. |
+
+<Tip>
+  If your agent must always converse in one specific language, leave Language detection off — the session then sticks to `speaking_language` regardless of what it hears.
+</Tip>
+
+<Note>
+  The voice model and the speaking language are independent settings: picking a voice does not change the language, and vice versa. Choose a voice that sounds natural in the language you configure.
+</Note>
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Agent configuration" icon="sliders" href="/agents/build/configuration">
+    System prompt, first message, and conversation settings.
+  </Card>
+  <Card title="System tools" icon="wrench" href="/agents/build/system-tools">
+    Language detection and other built-in capabilities.
+  </Card>
+  <Card title="Preview calls" icon="phone" href="/agents/test/preview-calls">
+    Talk to your draft agent and hear the voice live.
+  </Card>
+  <Card title="Versions & publishing" icon="rocket" href="/agents/deploy/versions-publishing">
+    How drafts become the live agent.
+  </Card>
+</CardGroup>

--- a/agents/build/webhook-tools.mdx
+++ b/agents/build/webhook-tools.mdx
@@ -1,0 +1,181 @@
+---
+title: "Webhook Tools"
+description: "Let your agent call your HTTP endpoints in the middle of a conversation"
+icon: "webhook"
+---
+
+A webhook tool lets your agent call an HTTP endpoint mid-conversation — look up an order, create a ticket, check availability — and use the response in its next reply. You declare the arguments; the agent fills them in from the conversation and the platform makes the request.
+
+<Note>
+Tools are workspace-level resources shared across agents. Removing a tool from an agent **detaches** it — the tool stays in your workspace and remains attached to other agents. Editing a tool updates every agent that uses it, and those agents show unpublished changes until you [publish](/agents/deploy/versions-publishing).
+</Note>
+
+## Create a webhook tool
+
+In the Builder, open **Tools** and choose **Add tool → Webhook**. A tool created from the Builder is attached to the current agent immediately; use the tool's **Access** tab to enable it for other agents.
+
+<Steps>
+  <Step title="Name and describe the tool">
+    The model decides when to call a tool based on its name and description. Write the description for the model: say what the tool does and when to use it — "Look up the status of an order. Use when the caller asks where their order is."
+  </Step>
+  <Step title="Declare arguments">
+    Each argument is a name plus a description. Arguments are exposed to the agent as tool parameters — the description tells the model what value to extract from the conversation.
+  </Step>
+  <Step title="Configure the request">
+    Pick a method (`GET`, `POST`, `PUT`, `PATCH`, or `DELETE` — default `POST`), the endpoint URL, a content type (default `application/json`), and an optional body template.
+  </Step>
+  <Step title="Add headers">
+    Attach authentication or any custom headers — they are sent with every webhook request.
+  </Step>
+  <Step title="Set response handling">
+    Choose a timeout (1–120 seconds, default 30) and how errors are surfaced to the agent.
+  </Step>
+</Steps>
+
+## Argument templating
+
+Reference any declared argument with `{{name}}` — in the URL, in the body template, or both. The platform substitutes the values the agent supplies before sending the request.
+
+```text Endpoint URL
+https://api.example.com/orders/{{order_number}}
+```
+
+```json Body template
+{
+  "subject": "{{subject}}",
+  "details": "{{details}}",
+  "source": "voice-agent"
+}
+```
+
+## Authentication headers
+
+Each header has a kind that identifies what it carries:
+
+| Kind | Wire value | Sent as |
+|---|---|---|
+| Custom | `custom` | The header name and value you provide, e.g. `X-API-Key` |
+| Bearer | `authorization_bearer` | An `Authorization` header — provide the full value, e.g. `Bearer <token>` |
+| Basic | `authorization_basic` | An `Authorization` header — provide the full value, e.g. `Basic <credentials>` |
+
+Header values are sent exactly as you store them. The Builder's Bearer and Basic presets create the `Authorization` header with the `Bearer ` or `Basic ` prefix pre-filled — complete the value with your credential.
+
+<Warning>
+Bearer and Basic authorization values are write-only. The API accepts them on create and update but never echoes them when you read the tool back: credential headers return `value: null`, with `has_secret: true` confirming a secret is stored. To rotate a secret, submit a new value.
+</Warning>
+
+## Timeouts and error handling
+
+`timeout_seconds` caps how long the platform waits for your endpoint: 1–120 seconds, default 30. Voice conversations happen live — keep endpoints fast, and lower the timeout so a slow backend can't stall the call.
+
+`error_handling` controls what the agent learns when a call fails (default `passthrough`):
+
+| Option | What the agent sees |
+|---|---|
+| `passthrough` | The error response, so the agent can react to it in conversation ("I couldn't find that order number"). |
+| `hide` | Only that the call failed — no error details reach the agent. |
+
+Use `hide` when error responses might leak internal details you don't want spoken aloud.
+
+## Mock responses
+
+A tool can store mock responses — canned payloads, each with a `name`, a `status_code` (100–599), a `content_type`, and a `body`. Mocks are saved with the tool's configuration for test scenarios, but they don't intercept anything yet: preview and live calls always hit the real endpoint.
+
+## Test your tool
+
+The tool editor's **Test** tab fires a real request at your endpoint. Fill in the arguments as JSON (pre-filled with a sample based on your declared arguments) and send — you get back the status code, latency, response headers, and response body. A failing test never blocks saving the tool.
+
+Response bodies are captured up to 64 KB; larger bodies are cut off and flagged with `response_truncated`.
+
+## Create tools via the API
+
+`POST /v1/agent/tools` creates a tool in your workspace. Tools created this way are not attached to any agent — enable them per agent afterwards.
+
+```bash Create a webhook tool
+curl --request POST https://api.fish.audio/v1/agent/tools \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "tool_type": "webhook",
+    "name": "create_ticket",
+    "description": "Open a support ticket. Use when the issue cannot be resolved in conversation.",
+    "arguments": [
+      { "name": "subject", "description": "One-line summary of the issue." },
+      { "name": "details", "description": "Full description of the problem." }
+    ],
+    "method": "POST",
+    "url": "https://api.example.com/tickets",
+    "content_type": "application/json",
+    "body_template": "{ \"subject\": \"{{subject}}\", \"details\": \"{{details}}\" }",
+    "headers": [
+      { "name": "X-API-Key", "value": "YOUR_API_KEY", "kind": "custom" }
+    ],
+    "timeout_seconds": 30,
+    "error_handling": "passthrough"
+  }'
+```
+
+## Escalate to a ticket mid-call
+
+When the agent can't resolve an issue, the strongest close is a ticket opened while the caller is still on the line, with the ticket number read back aloud. The `create_ticket` tool above is the entire integration — what makes it work is the prompt around it and the response your endpoint returns.
+
+**Set the escalation policy in the prompt.** The tool description says what the tool does; the [system prompt](/agents/build/configuration) says when escalating is the right move:
+
+```text System prompt excerpt
+If you cannot resolve the caller's issue, offer to open a support ticket.
+Confirm they agree before calling create_ticket. Write a one-line subject and
+put what the caller reported and what you already tried into the details.
+After the tool returns, read the ticket number back and say when to expect a
+reply.
+```
+
+**Return something worth saying.** With `error_handling: passthrough` (the default), the agent sees your response body and uses it in its next reply — so respond with what the caller should hear:
+
+```json Endpoint response
+{ "ticket_id": "T-1042", "expected_reply": "within 24 hours" }
+```
+
+Ticket numbers get spoken aloud: short, pronounceable IDs survive text-to-speech far better than UUIDs.
+
+<Note>
+  An in-call ticket depends on the model choosing to escalate. For a safety net
+  that catches every unresolved call — including those where the agent never
+  called the tool — pair this with [auto-ticketing from post-call
+  analysis](/agents/monitor/webhooks#auto-ticket-unresolved-calls).
+</Note>
+
+## Limits
+
+| Field | Limit |
+|---|---|
+| `name` | 1–120 characters. Display text — the model-facing function name is derived from it. [Client tool names](/agents/build/client-tools#naming-rules) are stricter: a 64-character pattern, since the SDK registers handlers by exact name |
+| `description` | up to 2,000 characters |
+| Argument `name` | 1–64 characters |
+| Argument `description` | up to 500 characters |
+| `url` | up to 4,000 characters |
+| `body_template` | up to 100,000 characters |
+| Mock response `body` | up to 100,000 characters |
+| Mock response `status_code` | 100–599 |
+| `timeout_seconds` | 1–120 seconds, default 30 |
+| Test response capture | first 64 KB (`response_truncated` set beyond that) |
+
+### URL restrictions
+
+Endpoint URLs must use `http` or `https`. Requests to localhost, private network ranges, and cloud metadata endpoints are rejected, and URLs may not embed credentials. The Builder validates the URL as you type; the API enforces the same rules.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Client tools" icon="browser" href="/agents/build/client-tools">
+    Run tool calls in your own app instead of over HTTP.
+  </Card>
+  <Card title="System tools" icon="gears" href="/agents/build/system-tools">
+    Built-in capabilities you toggle per agent.
+  </Card>
+  <Card title="Preview calls" icon="phone" href="/agents/test/preview-calls">
+    Talk to your agent and watch tool calls fire.
+  </Card>
+  <Card title="Agent tests" icon="vial" href="/agents/test/agent-tests">
+    Assert on agent behavior, tools included.
+  </Card>
+</CardGroup>

--- a/agents/concepts.mdx
+++ b/agents/concepts.mdx
@@ -1,0 +1,139 @@
+---
+title: "Core Concepts"
+sidebarTitle: "Concepts"
+description: "Workspaces, agents, versions, and sessions — the mental model behind Fish Agents"
+icon: "sitemap"
+---
+
+Four nouns cover the whole platform. A **workspace** holds everything your team builds. An **agent** is a voice assistant you configure. Publishing an agent's draft creates an immutable **version**. And every conversation with an agent — from your app, a phone call, or the console — is a **session**.
+
+## Workspaces
+
+A workspace is the isolation boundary for everything you create. Agents, tools, knowledge sources, and tests all belong to a workspace, and nothing in it is visible from any other workspace.
+
+Tools, knowledge sources, and tests are **workspace-level resources**, not per-agent ones: create a webhook tool once and attach it to as many agents as you like. Access controls in the console decide which agents can use each shared resource.
+
+Your API key belongs to your team: requests under `/v1/agent/*` can read and write agent resources across all of your team's workspaces, and each resource carries its `workspace_id`. Resources created through the API land in the key owner's default workspace:
+
+```bash List your team's agents
+curl https://api.fish.audio/v1/agent/agents \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+See [Authentication](/agents/deploy/authentication) for key setup.
+
+## Agents
+
+An agent is a bundle of configuration: a system prompt that steers behavior, a first-message policy, a [voice and speaking language](/agents/build/voice-language), attached [tools](/agents/build/tools), and [knowledge sources](/agents/build/knowledge-base). You assemble it in the Builder — the console page you land on after creating an agent — or through the API at `/v1/agent/agents`.
+
+Creating an agent takes only a name. Everything else is configured afterward, so start minimal and iterate.
+
+## Drafts and published versions
+
+Every agent has exactly one **draft** and any number of immutable **published versions**.
+
+<Steps>
+  <Step title="Edit the draft">
+    Everything you change in the Builder autosaves to the draft — there is no
+    Save button. Watch for the `Saving… / Saved` indicator.
+  </Step>
+  <Step title="Publish">
+    **Publish** snapshots the draft into a numbered, immutable version and makes
+    it the version that live traffic uses. The button is only enabled when the
+    draft actually differs from the latest published version.
+  </Step>
+  <Step title="Keep iterating">
+    Continue editing the draft without affecting live conversations. When you're
+    ready, publish again — the version number increments.
+  </Step>
+</Steps>
+
+### Live vs. Draft
+
+The agent list shows one of two states:
+
+| Badge     | Meaning                                    |
+| --------- | ------------------------------------------ |
+| **Live**  | The agent has been published at least once |
+| **Draft** | The agent has never been published         |
+
+Editing the draft of a Live agent does not change its badge — the Builder shows an unpublished-changes indicator next to **Publish** instead.
+
+### Which configuration runs
+
+- [Preview calls](/agents/test/preview-calls) in the Builder always run the **current draft**, so you can hear changes before anyone else does.
+- Sessions from the SDK, phone calls, and public agent links run the **latest published version**.
+
+<Tip>
+  This split is the core workflow: iterate on the draft, verify with a preview
+  call, then publish to roll the change out to real traffic.
+</Tip>
+
+### Restore and clone
+
+Past versions stay in the agent's history — review them or restore one back into the draft from [Versions & publishing](/agents/deploy/versions-publishing).
+
+**Clone** creates a new agent from an existing one's current draft: prompt, voice, and tool and knowledge attachments carry over (shared resources are referenced, not copied). The clone is named `{name} copy`, starts as Draft, and does not inherit the source's publish history.
+
+## Sessions
+
+A session is one conversation between one user and one agent. Sessions start from four places:
+
+<CardGroup cols={2}>
+  <Card title="Your app" icon="code" href="/agents/deploy/web-sdk">
+    A client connects with the [Web](/agents/deploy/web-sdk) or
+    [React](/agents/deploy/react-sdk) SDK.
+  </Card>
+  <Card title="Preview call" icon="headset" href="/agents/test/preview-calls">
+    You test the draft from the Builder.
+  </Card>
+  <Card title="Phone call" icon="phone" href="/agents/telephony/inbound-calls">
+    A caller dials a connected [phone number](/agents/telephony/phone-numbers).
+  </Card>
+  <Card title="Public agent" icon="globe" href="/agents/deploy/public-agents">
+    Anyone talks to an agent you've shared publicly.
+  </Card>
+</CardGroup>
+
+Except [preview calls](/agents/test/preview-calls), which are ephemeral and never enter history, every session appears in [Conversation history](/agents/monitor/conversation-history) and `/v1/agent/sessions` — with its transcript, and its recording when the agent [records audio](/agents/monitor/conversation-history#what-gets-stored) — and can trigger [post-call analysis](/agents/monitor/post-call-analysis) when configured.
+
+## Deleting resources
+
+Deletion is immediate and, from the console, cannot be undone: a deleted agent disappears from lists, the Builder, and all API responses. The same applies to tools, knowledge sources, and tests.
+
+<Note>
+  Names are freed on deletion — you can immediately create a new agent (or tool)
+  with the same name as one you deleted.
+</Note>
+
+## Where everything lives
+
+| Concept          | Console                                                                                                   | API resource                                                                          |
+| ---------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Agent            | **Agents** list → Builder                                                                                 | [`/v1/agent/agents`](/api-reference/endpoint/agent/list-agents)                       |
+| Draft & versions | Builder (autosave + **Publish**)                                                                          | [`/v1/agent/agents`](/api-reference/endpoint/agent/get-draft-config)                  |
+| Session          | [Preview calls](/agents/test/preview-calls), [Conversation history](/agents/monitor/conversation-history) | [`/v1/agent/sessions`](/api-reference/endpoint/agent/create-agent-session)            |
+| Tool             | Builder **Tools** page                                                                                    | [`/v1/agent/tools`](/api-reference/endpoint/agent/list-tools)                         |
+| Knowledge source | Builder **Knowledge base** page                                                                           | [`/v1/agent/knowledge-sources`](/api-reference/endpoint/agent/list-knowledge-sources) |
+| Phone number     | **Phone numbers** page                                                                                    | [`/v1/agent/phone-numbers`](/api-reference/endpoint/agent/list-phone-numbers)         |
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/agents/quickstart">
+    Create, configure, and talk to your first agent.
+  </Card>
+  <Card title="Configuration" icon="sliders" href="/agents/build/configuration">
+    System prompt, first message, and conversation settings.
+  </Card>
+  <Card
+    title="Versions & publishing"
+    icon="code-branch"
+    href="/agents/deploy/versions-publishing"
+  >
+    Publish history, restore, and rollout details.
+  </Card>
+  <Card title="Integrate" icon="plug" href="/agents/deploy/overview">
+    Put your agent in front of users with the SDKs.
+  </Card>
+</CardGroup>

--- a/agents/deploy/authentication.mdx
+++ b/agents/deploy/authentication.mdx
@@ -1,0 +1,234 @@
+---
+title: "Authentication"
+description: "Connect clients to your agent with a public agent ID or a backend-minted session token"
+icon: "key"
+---
+
+There are exactly two ways for a client to start a conversation with your agent. Pick one — there is no third path, and your API key is never one of them in the browser.
+
+<CardGroup cols={2}>
+  <Card title="Public agent ID" icon="globe">
+    The browser calls Fish Audio directly with just an `agentId`. No credential
+    — requires the agent to be [public](/agents/deploy/public-agents).
+  </Card>
+  <Card title="Session token" icon="server">
+    Your backend creates a session with your API key and hands the short-lived
+    token to the SDK. The default for private agents.
+  </Card>
+</CardGroup>
+
+|                           | Public agent ID                                                             | Session token                         |
+| ------------------------- | --------------------------------------------------------------------------- | ------------------------------------- |
+| Credential in browser     | None                                                                        | Short-lived session token             |
+| Requires                  | Agent set to public + allowed origins                                       | Your own backend endpoint             |
+| Session parameters set by | The SDK (`overrides`, `dynamicVariables`, `language`, `toolEvents` options) | Your backend, in the creation request |
+| Best for                  | Demos, marketing pages, low-friction embeds                                 | Production apps with signed-in users  |
+
+## Public agents: connect with an agent ID
+
+If the agent is public, the SDK creates the session itself — no backend, no credential:
+
+```javascript JavaScript
+import { AgentSession } from "@fishaudio/agent-client";
+
+const session = await AgentSession.start({
+  agentId: "YOUR_AGENT_ID",
+  dynamicVariables: { name: "Ada" },
+});
+```
+
+Fish Audio accepts the request only when the agent has public access enabled and the page's `Origin` is on the agent's allow-list; requests are rate-limited per IP and per agent. Origins match on exact scheme, host, and port — `localhost` and `127.0.0.1` are different origins, so list both during development. See [Public agents](/agents/deploy/public-agents) for setup.
+
+## Session tokens: mint on your backend
+
+For private agents, your backend exchanges your API key for a single-conversation token.
+
+<Steps>
+  <Step title="Create a session from your backend">
+    Call `POST /v1/agent/sessions` with your API key. This is where you set
+    per-session parameters — user identity, overrides, dynamic variables.
+  </Step>
+  <Step title="Return the response to your frontend">
+    The response is the session token. Forward it verbatim.
+  </Step>
+  <Step title="Start the SDK with the token">
+    Pass the object to `AgentSession.start({sessionToken})` unmodified. The SDK
+    handles the connection from there.
+  </Step>
+</Steps>
+
+<CodeGroup>
+```bash API (curl)
+curl --request POST https://api.fish.audio/v1/agent/sessions \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "agent_id": "YOUR_AGENT_ID",
+    "end_user_id": "user_42",
+    "dynamic_variables": { "name": "Ada" }
+  }'
+```
+
+```javascript Backend (Express)
+app.post("/voice-session", async (req, res) => {
+  const upstream = await fetch("https://api.fish.audio/v1/agent/sessions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.FISH_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      agent_id: "YOUR_AGENT_ID",
+      end_user_id: req.user.id,
+      dynamic_variables: { name: req.user.name },
+    }),
+  });
+  if (!upstream.ok) {
+    console.error("session creation failed:", upstream.status);
+    return res.status(502).json({ error: "session_unavailable" });
+  }
+  res.json(await upstream.json());
+});
+```
+
+```python Backend (Python)
+import os
+import requests
+
+def create_voice_session(end_user_id: str, name: str) -> dict:
+    response = requests.post(
+        "https://api.fish.audio/v1/agent/sessions",
+        headers={"Authorization": f"Bearer {os.environ['FISH_API_KEY']}"},
+        json={
+            "agent_id": "YOUR_AGENT_ID",
+            "end_user_id": end_user_id,
+            "dynamic_variables": {"name": name},
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+```javascript Browser
+import { AgentSession } from "@fishaudio/agent-client";
+
+const sessionToken = await fetch("/voice-session", { method: "POST" }).then(r =>
+  r.json()
+);
+
+const session = await AgentSession.start({ sessionToken });
+```
+
+</CodeGroup>
+
+<Note>
+  In session token mode, `overrides`, `dynamic_variables`, `language`,
+  `tool_events`, `timezone`, and `world_context` belong in your backend's
+  creation request — the SDK forwards these options only in public agent ID
+  mode.
+</Note>
+
+### Request fields
+
+| Field               | Type              | Description                                                                                                                                                                                                                                                                               |
+| ------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent_id`          | string, required  | The agent to talk to. It must have a [published version](/agents/deploy/versions-publishing).                                                                                                                                                                                             |
+| `name`              | string, optional  | Display name for this session in the console's Conversations list, up to 128 characters. Omit it to show the session's start time instead. API-key requests only — keyless (public) creation rejects it with `400`.                                                                       |
+| `language`          | string, optional  | Shorthand for `overrides.language`; subject to the same override allow-list. See [Voice & language](/agents/build/voice-language).                                                                                                                                                        |
+| `overrides`         | object, optional  | Per-session config overrides. Each field must be enabled in the agent's override allow-list — unauthorized fields are rejected with `400`.                                                                                                                                                |
+| `dynamic_variables` | object, optional  | Up to 50 entries of string, number, or boolean values, substituted into `{{placeholders}}`. See [Dynamic variables](/agents/build/dynamic-variables).                                                                                                                                     |
+| `tool_events`       | boolean, optional | Stream tool lifecycle events (`toolCallStarted` / `toolCallCompleted` / `toolCallFailed`) to the client. Default `true`; set `false` to keep tool inputs and outputs off the client.                                                                                                      |
+| `end_user_id`       | string, optional  | Your identifier for the end user, for attribution in [conversation history](/agents/monitor/conversation-history).                                                                                                                                                                        |
+| `metadata`          | object, optional  | Your own key-value namespace. Stored and returned verbatim on session queries and webhooks — never read or interpreted by the platform.                                                                                                                                                   |
+| `record_audio`      | boolean, optional | Whether to record this session's audio. Overrides the agent's [recording setting](/agents/monitor/conversation-history#what-gets-stored) for this session only — it never changes the agent; omit it to use the agent's configuration.                                                    |
+| `timezone`          | string, optional  | IANA timezone (like `Asia/Shanghai`) for the agent's sense of local time. Invalid names are rejected with `422`. See [Time & timezone](/agents/build/time-timezone).                                                                                                                      |
+| `client_timezone`   | string, optional  | The end user's browser timezone, filled automatically by the SDK in public-agent mode. A hint, not a demand: it applies only when neither `timezone` nor the agent's configured timezone is set, and invalid values are ignored. See the [resolution order](/agents/build/time-timezone). |
+| `world_context`     | boolean, optional | Whether the agent knows the current date and time. Default `true`; set `false` to withhold both from this session.                                                                                                                                                                        |
+
+Unknown fields — top-level or inside `overrides` — are rejected with `422`.
+
+### Response
+
+```json JSON
+{
+  "session_id": "abc123",
+  "expires_at": "2026-07-23T12:00:00Z",
+  "max_duration_seconds": 1800,
+  "transport": "livekit",
+  "livekit_url": "wss://example.livekit.cloud",
+  "token": "<participant token>"
+}
+```
+
+| Field                  | Description                                                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `session_id`           | The session's id — use it later to look up the [conversation record](/agents/monitor/conversation-history). |
+| `expires_at`           | Deadline for the client to connect. Mint the token right before starting, not ahead of time.                |
+| `max_duration_seconds` | Hard cap on session length.                                                                                 |
+| `transport`            | Which transport the SDK uses for this session; `livekit` today.                                             |
+| `livekit_url`, `token` | Connection details for that transport, consumed by the SDK.                                                 |
+
+Treat the response as opaque and pass it to `start()` unmodified. If the SDK does not recognize the `transport` value, it fails fast with an `unsupported_transport` error asking you to upgrade the SDK — it never silently degrades.
+
+### Token lifetime
+
+- A session token is **single-use**: `start()` consumes it once to establish the conversation.
+- On network drops the SDK reconnects at the transport level using the same connection state — it never re-creates the session, so you never need to re-mint mid-call.
+- Once a session ends, the token is spent. Mint a new token for each conversation.
+
+### Ending sessions from your backend
+
+A session normally ends from the client side — the user disconnects, or the agent [hangs up](/agents/build/system-tools). To force-end a live session server-side, call the end endpoint with your API key and the `session_id` from the creation response:
+
+```bash Request
+curl --request POST https://api.fish.audio/v1/agent/sessions/$SESSION_ID/end \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+The agent disconnects and the call terminates — the response is `204`. The session record stays readable in [conversation history](/agents/monitor/conversation-history), along with the transcript and recording when the agent [stores them](/agents/monitor/conversation-history#what-gets-stored). The same endpoint ends in-progress [phone calls](/agents/telephony/inbound-calls) too.
+
+## Keep API keys on the server
+
+<Warning>
+  Your API key grants full access to every resource in your team — agents,
+  sessions, tools, phone numbers. Never embed it in a browser, mobile app, or
+  any code you ship to users. The only credential that belongs in a client is
+  the session token, and the only credential-free path is a public agent ID.
+</Warning>
+
+## Error responses
+
+Session creation fails with standard HTTP statuses; the SDK surfaces them as a `FishAgentError` with `statusCode` set.
+
+| Status | Meaning                                                                                                                                       |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`  | An `overrides` field is not on the agent's override allow-list.                                                                               |
+| `401`  | Invalid API key. A request with no `Authorization` header at all is treated as a public-agent request instead.                                |
+| `402`  | Quota exceeded.                                                                                                                               |
+| `403`  | Public-agent request rejected: the agent is not public, or the page's `Origin` is not on the allow-list.                                      |
+| `409`  | Conflict — most commonly the agent has no published version yet. [Publish](/agents/deploy/versions-publishing) to resolve.                    |
+| `422`  | The request body failed validation — an unknown field, an unsupported `language` code, an invalid `timezone`, or an invalid dynamic variable. |
+| `429`  | Rate limited — a public-agent request exceeded the per-agent or per-IP limit.                                                                 |
+
+The complete status-code reference for every `/v1/agent` endpoint — error shapes, `400` vs `422`, conflict semantics — is on [Agents API errors](/api-reference/agent-errors).
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
+    Enable credential-free access with origin allow-lists.
+  </Card>
+  <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
+    Everything `AgentSession` can do once connected.
+  </Card>
+  <Card title="React SDK" icon="react" href="/agents/deploy/react-sdk">
+    Hooks and components for React apps.
+  </Card>
+  <Card
+    title="Dynamic variables"
+    icon="brackets-curly"
+    href="/agents/build/dynamic-variables"
+  >
+    Personalize each session at creation time.
+  </Card>
+</CardGroup>

--- a/agents/deploy/overview.mdx
+++ b/agents/deploy/overview.mdx
@@ -1,0 +1,117 @@
+---
+title: "Deploy Your Agent"
+sidebarTitle: "Overview"
+description: "Pick a deployment channel — embeddable widget, public agents, authenticated sessions, or a phone number"
+icon: "plug"
+---
+
+Your agent is one artifact with many front doors. Deployment is a ladder: start with the zero-code widget and climb only as far as your needs require — browser access without a backend, backend-minted sessions, or a phone number. Every channel runs the same agent with the same configuration.
+
+<Note>
+  Publishing gates every channel: sessions always run the agent's **published**
+  configuration, and creating a session against an agent that has never been
+  published fails. [Publish](/agents/deploy/versions-publishing) before wiring
+  up any channel.
+</Note>
+
+## Choose a channel
+
+In increasing order of integration effort and control:
+
+<CardGroup cols={2}>
+  <Card
+    title="1. Embeddable widget"
+    icon="puzzle-piece"
+    href="/agents/deploy/widget"
+  >
+    Drop a prebuilt call widget into your site — zero code.
+  </Card>
+  <Card
+    title="2. Public agents"
+    icon="globe"
+    href="/agents/deploy/public-agents"
+  >
+    Browser-only: the SDK connects with just an `agentId`, gated by an origin
+    allowlist and rate limits.
+  </Card>
+  <Card
+    title="3. Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authentication"
+  >
+    Your backend mints a session token; the Web or React SDK takes it from
+    there.
+  </Card>
+  <Card title="4. Phone" icon="phone" href="/agents/telephony/phone-numbers">
+    Bind a number and callers dial straight in — no client code at all.
+  </Card>
+</CardGroup>
+
+Building a client on a stack the SDKs don't cover? The [wire protocol](/agents/deploy/protocol) documents the wire-level session contract.
+
+Still deciding?
+
+| You are building                                   | Start with                                                                                                       |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| A call button on an existing site, no build step   | [Widget](/agents/deploy/widget)                                                                                  |
+| A demo or marketing page without a backend         | [Public agents](/agents/deploy/public-agents)                                                                    |
+| Voice calls inside a web app                       | [Authentication](/agents/deploy/authentication) and the [Web SDK](/agents/deploy/web-sdk)                        |
+| A React or Next.js frontend                        | [React SDK](/agents/deploy/react-sdk)                                                                            |
+| A phone line callers dial in to                    | [Phone numbers](/agents/telephony/phone-numbers) and [transfers](/agents/telephony/transfers)                    |
+| Server-side session creation and history retrieval | [Authentication](/agents/deploy/authentication) and [conversation history](/agents/monitor/conversation-history) |
+| A client on a stack the SDKs don't cover           | [Wire protocol](/agents/deploy/protocol)                                                                         |
+
+## How a browser session starts
+
+For private agents, your backend creates the session — your API key never ships to the browser. The browser SDK takes the resulting session token and handles audio and transport from there.
+
+<CodeGroup>
+```bash Your backend
+curl --request POST https://api.fish.audio/v1/agent/sessions \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{ "agent_id": "YOUR_AGENT_ID" }'
+# → 201 session token — return it to your frontend as-is
+```
+
+```javascript Your frontend
+import { AgentSession } from "@fishaudio/agent-client";
+
+// sessionToken = the create-session response, passed through unchanged
+const session = await AgentSession.start({ sessionToken });
+```
+
+</CodeGroup>
+
+<Tip>
+  Agents marked [public](/agents/deploy/public-agents) skip the backend step
+  entirely — the SDK connects with just an `agentId`, gated by an origin
+  allowlist and rate limits.
+</Tip>
+
+For phone calls there is no client integration: assign a number, and inbound calls connect directly to your agent — which can [transfer callers](/agents/telephony/transfers) to another number mid-call. See [Phone numbers](/agents/telephony/phone-numbers).
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card
+    title="Versions & publishing"
+    icon="rocket"
+    href="/agents/deploy/versions-publishing"
+  >
+    The publish step every channel depends on.
+  </Card>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    API keys, session tokens, and which one belongs where.
+  </Card>
+  <Card
+    title="Conversation history"
+    icon="clock-rotate-left"
+    href="/agents/monitor/conversation-history"
+  >
+    List sessions and read full transcripts over REST.
+  </Card>
+  <Card title="Wire protocol" icon="code" href="/agents/deploy/protocol">
+    The wire-level session contract, for building your own client.
+  </Card>
+</CardGroup>

--- a/agents/deploy/protocol.mdx
+++ b/agents/deploy/protocol.mdx
@@ -1,0 +1,175 @@
+---
+title: "Wire Protocol"
+description: "The realtime message contract between clients and agent sessions — for platforms the SDKs don't cover"
+icon: "network-wired"
+---
+
+Everything the SDKs do rides a small, versioned wire protocol: two JSON message channels, plus the transport's standard transcription and state mechanisms. This page documents that contract for consumers that cannot use the SDKs — custom native stacks or ports to new platforms.
+
+<Note>
+  This is an escape hatch. For web and React apps, use the [Web
+  SDK](/agents/deploy/web-sdk) or [React SDK](/agents/deploy/react-sdk) instead
+  — they implement everything below (connection, reconnection, message parsing,
+  tool dispatch) and stay current as the protocol evolves.
+</Note>
+
+## The protocol package
+
+Every message shape on this page is published as TypeScript definitions in `@fishaudio/agent-protocol` — zero runtime dependencies. This page documents protocol revision **0.3.0**; the npm package is versioned independently. The package is the source of truth for shapes; this page fixes the semantics.
+
+```bash npm
+npm install @fishaudio/agent-protocol
+```
+
+## Connect to a session
+
+Create a session server-side ([authentication](/agents/deploy/authentication)), then connect to the transport named in the response. [Public agents](/agents/deploy/public-agents) can create sessions without the `Authorization` header.
+
+```bash Create a session
+curl --request POST https://api.fish.audio/v1/agent/sessions \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{ "agent_id": "YOUR_AGENT_ID" }'
+```
+
+```json Response (201)
+{
+  "session_id": "...",
+  "expires_at": "2026-07-23T12:34:56Z",
+  "max_duration_seconds": 1800,
+  "transport": "livekit",
+  "livekit_url": "wss://...",
+  "token": "<participant JWT>"
+}
+```
+
+The response is a discriminated union on `transport`. The `livekit` arm carries `livekit_url` and `token`: connect a LiveKit-compatible WebRTC client with them before `expires_at` (the join deadline), publish your microphone track, and subscribe to the agent's audio track.
+
+<Warning>
+  If you receive a `transport` value you don't recognize, fail with an explicit
+  "unsupported transport" error. Never guess or silently degrade — new transport
+  arms may be introduced, each with its own payload.
+</Warning>
+
+## Channels
+
+Once connected, a session uses these channels. The two `*-event` topics carry reliable data packets — one complete JSON object per packet.
+
+| Channel                                | Direction      | Carries                                                   |
+| -------------------------------------- | -------------- | --------------------------------------------------------- |
+| Audio tracks                           | both           | Your microphone up, the agent's speech down               |
+| `agent-event` topic                    | agent → client | Control events: client tool calls, tool lifecycle, errors |
+| `client-event` topic                   | client → agent | Text turns, activity, interrupts, hangup, tool results    |
+| `lk.transcription` text streams        | agent → client | Streaming transcripts for both sides                      |
+| `lk.agent.state` participant attribute | agent → client | Agent pipeline state (sticky)                             |
+
+Data-channel message fields are camelCase; REST bodies are snake_case.
+
+## Agent events — `agent-event`
+
+### `client_tool.call`
+
+The agent wants to run a [client tool](/agents/build/client-tools) in your app.
+
+```json client_tool.call
+{
+  "type": "client_tool.call",
+  "callId": "call_abc",
+  "toolName": "open_dashboard",
+  "params": { "tab": "billing" },
+  "expectsResponse": true
+}
+```
+
+Run the tool, then publish a `client_tool.result` with the same `callId`. While `expectsResponse` is `true`, the agent suspends the model's tool call until your result arrives or the tool's configured timeout elapses (default 30 seconds, configurable from 1 to 120). When `expectsResponse` is `false`, the call is fire-and-forget: the agent continues immediately and any result you send is ignored.
+
+### Tool lifecycle — `tool.started`, `tool.completed`, `tool.failed`
+
+Each tool the agent invokes emits one `tool.started`, resolved by exactly one terminal message (`tool.completed` or `tool.failed`) with the same `callId`. Terminal messages repeat `toolName` and `toolSource`, so a client that missed the start can still render a complete entry.
+
+| Field                                | Type    | Notes                                                                                                        |
+| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------ |
+| `callId`                             | string  | Correlates a start with its terminal message                                                                 |
+| `toolName`                           | string  | The tool name as the model sees it                                                                           |
+| `toolSource`                         | string  | Where the tool runs: `client`, `webhook`, `mcp`, `builtin`, `background`, or `unknown`; treat as an open set |
+| `input` / `output`                   | string  | JSON-serialized payload, truncated at the source at 4 KB                                                     |
+| `inputTruncated` / `outputTruncated` | boolean | Present when the payload was truncated                                                                       |
+| `error`                              | string  | `tool.failed` only                                                                                           |
+
+These events are on by default and their payloads travel to the end user's client. Pass `tool_events: false` when creating the session to keep tool data off the wire — the session then receives none of the three.
+
+### `error`
+
+```json error
+{ "type": "error", "code": "provider_error" }
+```
+
+`code` is a coarse category only: `provider_error` (an upstream model or voice provider failed) or `internal_error` (the runtime failed). The message deliberately carries no raw error detail.
+
+## Client events — `client-event`
+
+Publish these on the `client-event` topic. The agent ignores malformed JSON and unknown types.
+
+| Type                 | Effect                                                                |
+| -------------------- | --------------------------------------------------------------------- |
+| `user.message`       | Injects a text user turn; the agent replies as if the user had spoken |
+| `user.activity`      | Signals user activity (typing); suppresses idle re-engagement         |
+| `user.interrupt`     | Explicitly interrupts the agent's current speech                      |
+| `user.hangup`        | Ends the session gracefully                                           |
+| `client_tool.result` | Settles a pending `client_tool.call`                                  |
+
+```json user.message
+{ "type": "user.message", "text": "What's my balance?" }
+```
+
+```json client_tool.result
+{
+  "type": "client_tool.result",
+  "callId": "call_abc",
+  "result": { "opened": true }
+}
+```
+
+- `user.message` gets **no server echo** — you already hold the text, so render the bubble locally. Add `"audio": false` (protocol 0.3.0) to have the agent answer that turn in text only: no speech is synthesized and the reply arrives over transcription.
+- `client_tool.result` may carry `result` (any JSON value) or `"isError": true` to report the tool as failed to the model. Results for unknown or already-settled `callId`s are ignored.
+
+## Transcription and agent state
+
+These ride the transport's built-in mechanisms rather than custom messages.
+
+**Transcription** arrives as text streams on the `lk.transcription` topic. Segments are identified by the `lk.segment_id` stream attribute; `lk.transcription_final: "true"` marks a segment as final. Roles are distinguished by sender identity: the user's segments are sent under the user's own participant identity, the agent's under the agent participant.
+
+- Agent segments stream incrementally, paced to audio playback. An interrupted segment closes containing only the words actually spoken — there is no residual text.
+- User segments are interim until final; each interim update **replaces the entire segment text** under the same segment id.
+
+**Agent state** is published as the sticky `lk.agent.state` participant attribute with values `initializing`, `idle`, `listening`, `thinking`, and `speaking`. Sticky means a client that connects late or reconnects reads the current value immediately. The SDKs derive their three public modes from this attribute plus transcript segment open/close.
+
+## Compatibility rules
+
+1. **Ignore unknown `type` values and unknown fields.** This is required consumer behavior and the foundation of forward compatibility.
+2. **Evolution is additive-only.** Published fields never change name or meaning and are never removed; new fields are always optional. A semantic change ships as a new `type`.
+3. **No replay.** Data-channel delivery is reliable and ordered within a connection, but after a reconnect or late join, missed messages are gone — never wait for history. Tool terminal messages repeat their identifying fields, and the state attribute is sticky, precisely to soften this.
+
+## Protocol revision history
+
+| Revision        | Changes                                                                                                              |
+| --------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 0.2.0           | Added tool lifecycle events (`tool.started` / `tool.completed` / `tool.failed`) and the `tool_events` session option |
+| 0.3.0 (current) | Added the optional `audio` flag on `user.message` for per-turn text-only replies                                     |
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
+    The supported implementation of this protocol for browsers.
+  </Card>
+  <Card title="Client tools" icon="wrench" href="/agents/build/client-tools">
+    Declare the tools your `client_tool.call` handlers implement.
+  </Card>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    Session creation, API keys, and token handling.
+  </Card>
+  <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
+    Let clients create sessions without a backend.
+  </Card>
+</CardGroup>

--- a/agents/deploy/public-agents.mdx
+++ b/agents/deploy/public-agents.mdx
@@ -1,0 +1,142 @@
+---
+title: "Public Agents"
+description: "Let visitors talk to your agent directly from the browser — no backend required"
+icon: "globe"
+---
+
+A public agent accepts sessions straight from the browser: the SDK calls the session endpoint with just an `agent_id` — no API key, no server of your own. The platform gates access with three controls: an agent-level public switch (off by default), a required origin allowlist, and rate limiting.
+
+Use this mode for demos, marketing pages, and support bubbles where standing up a backend isn't worth it. For production apps with their own users, [session tokens](/agents/deploy/authentication) are usually the better fit — see [when to use session tokens instead](#when-to-use-session-tokens-instead).
+
+## Enable public access
+
+<Steps>
+  <Step title="Publish the agent">
+    Public sessions always run the agent's **published** configuration. An
+    unpublished agent rejects session creation. See [Versions &
+    publishing](/agents/deploy/versions-publishing).
+  </Step>
+  <Step title="Turn on the public switch">
+    On the agent's **Deploy** page in the console, turn on **Public access**. It
+    is **off by default** — until you enable it, sessions require
+    authentication.
+  </Step>
+  <Step title="Add allowed origins">
+    On the same page, list every web origin that may start sessions under
+    **Allowed origins** (`allowed_origins` in the API). The allowlist is
+    **required**: a request whose `Origin` doesn't match any entry is rejected
+    with `403`.
+  </Step>
+</Steps>
+
+## Start a session from the browser
+
+Pass `agentId` to the SDK and it creates the session directly with the Fish Audio API, then connects the audio — your page never handles credentials.
+
+<CodeGroup>
+
+```javascript JavaScript
+import { AgentSession } from "@fishaudio/agent-client";
+
+const session = await AgentSession.start({
+  agentId: "YOUR_AGENT_ID",
+});
+
+session.on("agentResponse", ({ text }) => console.log("Agent:", text));
+```
+
+```bash API (curl)
+# No Authorization header — the Origin header is checked instead.
+# Browsers send Origin automatically; curl must set it explicitly.
+curl --request POST https://api.fish.audio/v1/agent/sessions \
+  --header "Content-Type: application/json" \
+  --header "Origin: https://app.example.com" \
+  --data '{ "agent_id": "YOUR_AGENT_ID" }'
+```
+
+</CodeGroup>
+
+The response is the same session token an authenticated request returns — the SDK consumes it internally. Everything else (events, methods, client tools) works exactly as in the [Web SDK](/agents/deploy/web-sdk).
+
+## Origin matching
+
+An entry matches only on **exact scheme + host + port**. The host is case-insensitive, and a trailing slash on an entry is tolerated — everything else must match exactly.
+
+| Allowlist entry           | Browser origin                 | Allowed                        |
+| ------------------------- | ------------------------------ | ------------------------------ |
+| `https://app.example.com` | `https://app.example.com`      | Yes                            |
+| `https://app.example.com` | `https://APP.example.com`      | Yes — host is case-insensitive |
+| `https://app.example.com` | `http://app.example.com`       | No — scheme differs            |
+| `https://app.example.com` | `https://app.example.com:8443` | No — port differs              |
+| `http://localhost:5173`   | `http://127.0.0.1:5173`        | No — different hosts           |
+
+<Warning>
+`localhost` and `127.0.0.1` are **different origins**. If you develop against both, list both:
+
+```text
+http://localhost:5173
+http://127.0.0.1:5173
+```
+
+</Warning>
+
+## Rate limiting
+
+Public session creation is rate limited on two dimensions at once: per **client IP** and per **agent**. Either limit being exceeded rejects the request. Sessions started on a public agent are billed to the workspace that owns the agent.
+
+<Note>
+  If legitimate traffic outgrows these limits, or you need per-user quotas, move
+  to [session token authentication](/agents/deploy/authentication) — your
+  backend becomes the gate, and the platform-side public limits no longer apply.
+</Note>
+
+## Treat public input as untrusted
+
+On the public path, the entire session request originates in the visitor's browser. The platform enforces its own guardrails — `overrides` are filtered against the agent's allowlist and unauthorized fields are rejected with `400` — but anything that passes through verbatim is attacker-controllable:
+
+- **`metadata`** is stored and returned exactly as sent, never interpreted by the platform. When you read it back in [conversation history](/agents/monitor/conversation-history) or [webhooks](/agents/monitor/webhooks), treat it as untrusted data — never as proof of who the visitor is.
+- **`dynamic_variables`** are chosen by the page that starts the session. Don't inject anything through them that the visitor shouldn't control. See [Dynamic variables](/agents/build/dynamic-variables).
+
+For trusted attribution (a verified `end_user_id`, server-set metadata), create sessions from your backend instead.
+
+## Errors
+
+Public-mode failures surface as `FishAgentError` codes on `AgentSession.start()`:
+
+| Code                     | Meaning                                                                    |
+| ------------------------ | -------------------------------------------------------------------------- |
+| `agent_not_public`       | The agent's public switch is off.                                          |
+| `origin_forbidden`       | The page's origin is not in `allowed_origins` (HTTP `403`).                |
+| `session_request_failed` | Other creation failures — for example, the agent has no published version. |
+
+## When to use session tokens instead
+
+Public mode trades control for zero setup. Prefer the `sessionToken` flow — your backend calls the session endpoint with an API key and hands the token to the browser — when any of these apply:
+
+- The agent should stay **private** rather than callable by anyone who loads your page.
+- You need **trusted attribution**: an `end_user_id` and `metadata` set by your server, not the browser.
+- You want server-side control of `overrides`, `dynamic_variables`, or `tool_events` instead of accepting the browser's values.
+- You already authenticate users and want **your own quotas** per account, not IP-based platform limits.
+
+The SDK call changes by one field — pass `{ sessionToken }` instead of `{ agentId }`. See [Authentication](/agents/deploy/authentication) for the full flow.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    Both auth modes side by side, and the session token flow in full.
+  </Card>
+  <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
+    Events, methods, and client tools — identical in both modes.
+  </Card>
+  <Card title="React SDK" icon="react" href="/agents/deploy/react-sdk">
+    Hooks and components for React apps.
+  </Card>
+  <Card
+    title="Conversation history"
+    icon="clock-rotate-left"
+    href="/agents/monitor/conversation-history"
+  >
+    Review what public visitors said to your agent.
+  </Card>
+</CardGroup>

--- a/agents/deploy/react-sdk.mdx
+++ b/agents/deploy/react-sdk.mdx
@@ -1,0 +1,197 @@
+---
+title: "React SDK"
+description: "Add voice conversations to your React app with hooks and drop-in components"
+icon: "react"
+---
+
+`@fishaudio/agent-react` wraps the [Web SDK](/agents/deploy/web-sdk) in idiomatic React: a `useConversation` hook for session control, an optional provider that shares one session across your component tree, and a ready-made audio visualizer. The SDK handles microphone capture, audio playback, and transport internally — you write UI.
+
+<CardGroup cols={3}>
+  <Card title="Web SDK reference" icon="js" href="/agents/deploy/web-sdk">
+    Every event, method, and error code.
+  </Card>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    Create session tokens on your backend.
+  </Card>
+  <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
+    Connect with just an agent id, no backend.
+  </Card>
+</CardGroup>
+
+## Install
+
+<CodeGroup>
+```bash npm
+npm install @fishaudio/agent-react
+```
+
+```bash pnpm
+pnpm add @fishaudio/agent-react
+```
+
+```bash yarn
+yarn add @fishaudio/agent-react
+```
+
+</CodeGroup>
+
+## Quick start
+
+A minimal call UI: start a call, show what the agent is doing, mute, hang up. This example connects to a [public agent](/agents/deploy/public-agents) by id.
+
+```tsx App.tsx
+import { useConversation } from "@fishaudio/agent-react";
+
+export function CallButton() {
+  const {
+    startSession,
+    endSession,
+    status,
+    mode,
+    isSpeaking,
+    micMuted,
+    setMicMuted,
+  } = useConversation();
+
+  if (status === "connected" || status === "reconnecting") {
+    const label = isSpeaking
+      ? "Agent is speaking"
+      : mode === "thinking"
+        ? "Thinking..."
+        : "Listening";
+
+    return (
+      <div>
+        <p>{label}</p>
+        <button onClick={() => setMicMuted(!micMuted)}>
+          {micMuted ? "Unmute" : "Mute"}
+        </button>
+        <button onClick={() => endSession()}>Hang up</button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      disabled={status === "connecting"}
+      onClick={() => startSession({ agentId: "YOUR_AGENT_ID" })}
+    >
+      Start call
+    </button>
+  );
+}
+```
+
+`status`, `mode`, and `isSpeaking` are React state — your component re-renders as the conversation progresses. When the component unmounts, the session ends automatically.
+
+<Note>
+  Call `startSession` from a user gesture (such as a click handler) so the
+  browser allows microphone capture and audio playback.
+</Note>
+
+### Connect to a private agent
+
+For agents that are not public, your backend creates the session with your API key (`POST /v1/agent/sessions`) and returns the response to the browser. Pass it to `startSession` unchanged.
+
+```tsx
+const res = await fetch("/api/voice-session", { method: "POST" });
+const sessionToken = await res.json();
+await startSession({ sessionToken });
+```
+
+See [Authentication](/agents/deploy/authentication) for the backend side. `startSession` accepts the same options as `AgentSession.start` in the [Web SDK](/agents/deploy/web-sdk), including [`clientTools`](/agents/build/client-tools). Session settings such as `overrides` and `dynamicVariables` apply when you connect with an `agentId`; with a `sessionToken`, your backend sets them in its session-creation request instead.
+
+## What `useConversation` returns
+
+| Field                             | Description                                                                               |
+| --------------------------------- | ----------------------------------------------------------------------------------------- |
+| `startSession(options)`           | Create and connect a session (`agentId` or `sessionToken`)                                |
+| `endSession()`                    | Hang up gracefully                                                                        |
+| `status`                          | `"idle"` (no session yet) / `"connecting"` / `"connected"` / `"reconnecting"` / `"ended"` |
+| `mode`                            | `"listening"` / `"thinking"` / `"speaking"`                                               |
+| `isSpeaking`                      | `true` while the agent is audibly speaking                                                |
+| `micMuted`, `setMicMuted(muted)`  | Microphone mute state                                                                     |
+| `sendUserMessage(text, options?)` | Send a typed message as a user turn                                                       |
+| `sendUserActivity()`              | Signal that the user is typing, so the agent holds back                                   |
+| `interrupt()`                     | Explicitly stop the agent mid-response                                                    |
+| `session`                         | The live `AgentSession` object (`null` before the first start) for direct event access    |
+
+<Tip>
+`sendUserMessage(text)` injects a typed turn; the agent's reply streams back as transcript and audio. Pass `{ audio: false }` to get a text-only reply for that turn — useful for a do-not-disturb typing mode.
+</Tip>
+
+For transcripts, tool-call events, and error handling, subscribe to events on `session` — see the [Web SDK event reference](/agents/deploy/web-sdk).
+
+## Share one session across components
+
+Wrap your tree in `AgentSessionProvider` when several components need the same conversation — call controls in the header, a transcript panel elsewhere.
+
+```tsx App.tsx
+import { AgentSessionProvider, useAgentMessages } from "@fishaudio/agent-react";
+
+export function App() {
+  return (
+    <AgentSessionProvider>
+      <CallButton />
+      <Transcript />
+    </AgentSessionProvider>
+  );
+}
+
+function Transcript() {
+  const messages = useAgentMessages();
+
+  return (
+    <ul>
+      {messages.map(m => (
+        <li key={m.key}>
+          <strong>{m.role === "agent" ? "Agent" : "You"}</strong>: {m.text}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+The provider hosts the conversation, so components inside it read the shared state with `useAgentSessionContext()` instead of calling `useConversation` themselves — it returns the same fields, so the quick-start `CallButton` only needs its hook call swapped.
+
+| Hook                             | Purpose                                                                                                                                 |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `useAgentSessionContext()`       | Access the active session from anywhere inside the provider                                                                             |
+| `useAgentMessages()`             | Live conversation as a list of `{ key, role, text, final }` messages — segments update in place as they stream, no manual aggregation   |
+| `useAudioLevels(session?, fps?)` | Live input and output volume as `{ input, output }` (0–1), polled `fps` times per second (default 20); lower `fps` to reduce re-renders |
+
+## Audio visualizer
+
+`<AgentAudioVisualizer>` renders animated canvas bars driven by the agent's output audio — a drop-in "the agent is talking" indicator. Inside an `AgentSessionProvider` it picks up the active session automatically; elsewhere, pass a `session` prop. Optional `bars`, `width`, `height`, and `className` props control the rendering, and the bars follow the element's CSS `color`.
+
+```tsx
+import { AgentAudioVisualizer } from "@fishaudio/agent-react";
+
+function CallScreen() {
+  return <AgentAudioVisualizer />;
+}
+```
+
+For a custom visualization, build on `useAudioLevels` or the session's frequency-data methods from the [Web SDK](/agents/deploy/web-sdk).
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
+    Full event and method reference behind these hooks.
+  </Card>
+  <Card title="Client tools" icon="wrench" href="/agents/build/client-tools">
+    Let the agent call functions in your app.
+  </Card>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    Create session tokens server-side for private agents.
+  </Card>
+  <Card
+    title="Dynamic variables"
+    icon="brackets-curly"
+    href="/agents/build/dynamic-variables"
+  >
+    Personalize each session at start time.
+  </Card>
+</CardGroup>

--- a/agents/deploy/versions-publishing.mdx
+++ b/agents/deploy/versions-publishing.mdx
@@ -1,0 +1,176 @@
+---
+title: "Versions & Publishing"
+description: "Edit safely in a draft, then publish an immutable version that live sessions run"
+icon: "code-branch"
+---
+
+Every agent has one **draft** and a linear history of **published versions**. Edits in the Builder or via the API always land in the draft — production sessions never see them until you publish. Publishing snapshots the draft into an immutable, numbered version, so you can iterate freely without touching live traffic.
+
+<CardGroup cols={3}>
+  <Card
+    title="Edit the draft"
+    icon="sliders"
+    href="/agents/build/configuration"
+  >
+    Prompt, voice, and conversation settings — all autosaved.
+  </Card>
+  <Card
+    title="Test before publishing"
+    icon="phone"
+    href="/agents/test/preview-calls"
+  >
+    Preview calls talk to the draft, not the live version.
+  </Card>
+  <Card
+    title="Automate via API"
+    icon="brackets-curly"
+    href="/agents/deploy/overview"
+  >
+    Manage drafts, publishing, and version history programmatically.
+  </Card>
+</CardGroup>
+
+## Draft vs. published
+
+|            | Draft                                                                                   | Published version                             |
+| ---------- | --------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Mutability | Editable — Builder and `PATCH .../config` write here                                    | Immutable snapshot                            |
+| Used by    | [Preview calls](/agents/test/preview-calls) and [agent tests](/agents/test/agent-tests) | Production sessions — web, SDK, and phone     |
+| History    | One per agent, always current                                                           | `version_number` increments with each publish |
+
+<Note>
+  An agent that has never been published cannot take production sessions —
+  session creation returns `409` until the first publish. Publishing is the
+  single gate between editing and live traffic.
+</Note>
+
+## Publish from the Builder
+
+<Steps>
+  <Step title="Edit — changes autosave">
+    There is no Save button. Every change is written to the draft automatically;
+    the **Saving… / Draft saved** indicator in the top bar shows the current
+    state.
+  </Step>
+  <Step title="Watch the unpublished-changes indicator">
+    When the draft differs from the last published version, the **Publish**
+    button becomes active with an unpublished-changes hint next to it. When
+    there is nothing new to publish, the button is disabled. An agent that has
+    never been published always counts as having changes.
+  </Step>
+  <Step title="Publish">
+    Click **Publish**. Any pending edits are saved first, then the draft is
+    snapshotted as the next version. A confirmation shows the new version
+    number, and the agent shows as **Live** in your agents list.
+  </Step>
+</Steps>
+
+New sessions use the newly published version from that point on. To hear a change before it goes live, run a [preview call](/agents/test/preview-calls) — previews always use the draft.
+
+## Publish via the API
+
+Configuration edits (`PATCH`) go to the draft; a separate `publish` call rolls them out. A `version_title` and `version_description` are optional and make the version history easier to audit:
+
+<CodeGroup>
+```bash Update the draft
+curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "prompt": { "system_prompt": "You are a concise support agent for Acme." }
+  }'
+```
+
+```bash Publish
+curl --request POST "https://api.fish.audio/v1/agent/agents/$AGENT_ID/publish" \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{ "version_title": "Tighten support tone" }'
+```
+
+</CodeGroup>
+
+The publish response includes the new `version_number`.
+
+## Version history
+
+List published versions, or fetch the complete configuration snapshot of any one of them — including the version currently serving production:
+
+<CodeGroup>
+```bash List versions
+curl "https://api.fish.audio/v1/agent/agents/$AGENT_ID/versions" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+```bash Get one version's snapshot
+curl "https://api.fish.audio/v1/agent/agents/$AGENT_ID/versions/3" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+</CodeGroup>
+
+Each version record includes:
+
+| Field                 | Description                               |
+| --------------------- | ----------------------------------------- |
+| `version_number`      | Auto-incrementing, unique per agent       |
+| `version_title`       | Optional label sent when publishing       |
+| `version_description` | Optional description sent when publishing |
+| `config_hash`         | Fingerprint of the configuration snapshot |
+| `published_at`        | When the version was published            |
+
+Fetching a single version returns the full configuration as it was published. Because `GET .../config` always shows the draft, the snapshot endpoint is how you read back what is actually running in production.
+
+<Warning>
+  Version snapshots never echo credential secrets. Write-only fields — such as
+  webhook secrets and tool authorization headers — return a `has_secret: true`
+  marker instead of the value, in every version including historical ones.
+</Warning>
+
+## Restore a previous version
+
+Roll back by copying an old snapshot back into the draft: read the version you want, then `PATCH` its sections into the draft config.
+
+<CodeGroup>
+```bash 1. Read the old snapshot
+curl "https://api.fish.audio/v1/agent/agents/$AGENT_ID/versions/2" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+```bash 2. Patch it back into the draft
+curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{ "prompt": { "system_prompt": "<system prompt from the snapshot>" } }'
+```
+
+</CodeGroup>
+
+Patching updates the draft — it does **not** publish. Review or [preview](/agents/test/preview-calls) the restored draft, then publish it as a new version; the rollback becomes part of the linear history, so the audit trail stays intact. Because snapshots never echo secrets (see above), credential fields keep their current draft values unless you set them again explicitly.
+
+## Clone an agent
+
+Cloning creates a new agent from an existing one's **draft** configuration. In the console, open the agents list and choose **Clone** from the agent's row menu.
+
+The clone starts with a copy of the source's current draft. Published versions do not carry over — the new agent is unpublished until you publish it yourself. Use clones to template a base configuration across many agents, or to experiment without risking an agent that is already live.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card
+    title="Agent configuration"
+    icon="sliders"
+    href="/agents/build/configuration"
+  >
+    Everything that lives in the draft: prompt, voice, conversation settings.
+  </Card>
+  <Card title="Preview calls" icon="phone" href="/agents/test/preview-calls">
+    Talk to the draft before it ships.
+  </Card>
+  <Card title="Agent tests" icon="vial" href="/agents/test/agent-tests">
+    Run regression tests against the draft, then publish with confidence.
+  </Card>
+  <Card title="Integration overview" icon="plug" href="/agents/deploy/overview">
+    Connect published agents to your product via SDK and API.
+  </Card>
+</CardGroup>

--- a/agents/deploy/web-sdk.mdx
+++ b/agents/deploy/web-sdk.mdx
@@ -1,0 +1,274 @@
+---
+title: "Web SDK"
+description: "Voice sessions in the browser with @fishaudio/agent-client — events, transcripts, text input, audio controls, and client tools"
+icon: "js"
+---
+
+`@fishaudio/agent-client` runs a live voice conversation with your agent from any web page: open the microphone, stream audio both ways, and react to typed events for transcripts, agent state, and tool calls. The SDK handles the realtime transport (WebRTC) internally — your code never touches connection plumbing.
+
+Using React? [`@fishaudio/agent-react`](/agents/deploy/react-sdk) wraps this SDK in hooks and a provider.
+
+## Install
+
+<CodeGroup>
+```bash npm
+npm install @fishaudio/agent-client
+```
+
+```bash pnpm
+pnpm add @fishaudio/agent-client
+```
+
+```bash yarn
+yarn add @fishaudio/agent-client
+```
+
+</CodeGroup>
+
+## Start a session
+
+`AgentSession.start()` creates the session, connects, and opens the microphone in one call. Authenticate one of two ways:
+
+- **`agentId`** — for [public agents](/agents/deploy/public-agents). The SDK creates the session directly from the browser; no backend needed.
+- **`sessionToken`** — for private agents. Your backend calls `POST /v1/agent/sessions` with your API key and hands the JSON response to the browser; pass it through unchanged. See [Authentication](/agents/deploy/authentication).
+
+<CodeGroup>
+
+```javascript Public agent
+import { AgentSession } from "@fishaudio/agent-client";
+
+const session = await AgentSession.start({
+  agentId: "YOUR_AGENT_ID",
+});
+```
+
+```javascript Private agent
+import { AgentSession } from "@fishaudio/agent-client";
+
+// Your backend calls POST /v1/agent/sessions and returns the
+// response body. Pass it to the SDK as-is — no reshaping.
+const resp = await fetch("/api/voice-session", { method: "POST" });
+const sessionToken = await resp.json();
+
+const session = await AgentSession.start({ sessionToken });
+```
+
+</CodeGroup>
+
+### Options
+
+| Option                     | Type                                          | Description                                                                                                                                                                                                                                                                                                                     |
+| -------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agentId` / `sessionToken` | —                                             | One of the two, required                                                                                                                                                                                                                                                                                                        |
+| `clientTools`              | `Record<string, ClientToolHandler>`           | Handlers for [client tools](/agents/build/client-tools) declared on the agent                                                                                                                                                                                                                                                   |
+| `overrides`                | `SessionOverrides`                            | Per-session config overrides (`agentId` mode only — with `sessionToken`, your backend sends them when creating the session)                                                                                                                                                                                                     |
+| `dynamicVariables`         | `Record<string, string \| number \| boolean>` | Values for `{{placeholders}}` in the agent config — see [Dynamic variables](/agents/build/dynamic-variables)                                                                                                                                                                                                                    |
+| `language`                 | `string`                                      | Shorthand for overriding the agent's language                                                                                                                                                                                                                                                                                   |
+| `toolEvents`               | `boolean`                                     | Whether tool lifecycle events reach this client (default `true`; `agentId` mode only — with `sessionToken`, your backend sets `tool_events`)                                                                                                                                                                                    |
+| `timezone`                 | `string`                                      | IANA timezone for the agent's sense of local time — the top of the [resolution order](/agents/build/time-timezone), overriding the agent's configured timezone. When omitted, the SDK still sends the browser timezone as a lower-priority hint (`client_timezone`), which applies only if the agent has no timezone configured |
+| `worldContext`             | `boolean`                                     | Whether the agent knows the current date and time (default `true`; `agentId` mode only — with `sessionToken`, your backend sets `world_context`)                                                                                                                                                                                |
+| `audio`                    | `{ inputDeviceId?, outputDeviceId? }`         | Pick specific microphone and output devices                                                                                                                                                                                                                                                                                     |
+| `callbacks`                | `Partial<AgentSessionCallbacks>`              | Shorthand — each key is auto-subscribed via `.on()`                                                                                                                                                                                                                                                                             |
+
+## Session lifecycle
+
+A session moves through a fixed state machine, surfaced by the `statusChange` event and the `session.status` property:
+
+```text States
+connecting → connected ⇄ reconnecting → ended(reason)
+      └───────────(failure)───────────→ ended
+```
+
+When the session ends, `disconnect` fires with a reason (also available as `session.endReason`):
+
+| `EndReason`       | Meaning                                                                                                                                                                                                                        |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `user_hangup`     | You called `session.end()`                                                                                                                                                                                                     |
+| `agent_hangup`    | The server ended the session — the agent hung up (for example via the hang-up [system tool](/agents/build/system-tools)), the session hit its maximum duration, or it was force-ended; the protocol does not distinguish these |
+| `connection_lost` | The connection dropped and could not be recovered                                                                                                                                                                              |
+
+Brief network drops don't end the session: the SDK moves to `reconnecting` and back to `connected` automatically, reusing the same session.
+
+<Warning>
+  Events are not replayed after a reconnect. Anything emitted while you were in
+  `reconnecting` — transcript updates, tool events, errors — is dropped, not
+  resent. Design your UI to tolerate gaps: tool `toolCallCompleted` /
+  `toolCallFailed` events repeat the tool name and source, so a terminal event
+  still renders even if you missed `toolCallStarted`.
+</Warning>
+
+## Events
+
+The session is a typed event emitter — subscribe with `session.on(event, handler)`, remove with `off`, or use `once`.
+
+| Event                | Payload                                                 | Fires when                                                                  |
+| -------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `connect`            | `{ sessionId }`                                         | The session is connected and live                                           |
+| `disconnect`         | `{ reason: EndReason }`                                 | The session has ended                                                       |
+| `statusChange`       | `SessionStatus`                                         | Status transitions (`connecting` / `connected` / `reconnecting` / `ended`)  |
+| `modeChange`         | `AgentMode`                                             | The agent switches between `listening`, `thinking`, and `speaking`          |
+| `userTranscript`     | `{ segmentId, text, final }`                            | The user's speech is transcribed; interim updates replace the whole segment |
+| `agentResponseDelta` | `{ segmentId, delta, text }`                            | The agent speaks — `delta` is the new text, `text` the segment so far       |
+| `agentResponse`      | `{ segmentId, text }`                                   | An agent segment is finalized                                               |
+| `message`            | `{ role: "user" \| "agent", text }`                     | A finalized message from either side — a ready-made chat feed               |
+| `toolCallStarted`    | `{ callId, toolName, source, input, inputTruncated }`   | A tool call begins; `input` is a JSON string (truncated at 4 KB)            |
+| `toolCallCompleted`  | `{ callId, toolName, source, output, outputTruncated }` | A tool call succeeds                                                        |
+| `toolCallFailed`     | `{ callId, toolName, source, error }`                   | A tool call fails                                                           |
+| `error`              | `FishAgentError`                                        | A session or tool error occurs — see [Errors](#errors)                      |
+
+```javascript Subscribe to events
+session.on("userTranscript", ({ segmentId, text, final }) => {
+  upsertBubble("user", segmentId, text, final);
+});
+
+session.on("agentResponseDelta", ({ segmentId, text }) => {
+  upsertBubble("agent", segmentId, text, false);
+});
+
+session.on("modeChange", mode => setOrbState(mode));
+session.on("disconnect", ({ reason }) => showCallEnded(reason));
+```
+
+### Transcript semantics
+
+Transcripts on both sides arrive as **segments** — one segment per utterance or response, identified by `segmentId`:
+
+- **User segments**: interim results **replace the entire segment text** (they never append). Render by upserting on `segmentId`; `final: true` marks the segment as finalized.
+- **Agent segments**: text streams in sync with audio playback — what you display matches what the user has actually heard. If the agent is interrupted, the segment finalizes containing only the words that were spoken.
+- The `message` event delivers only finalized messages from both sides, in order — use it when you want a simple transcript list without handling interim updates.
+
+## Agent modes
+
+`session.mode` (and the `modeChange` event) tracks what the agent is doing, for driving an orb or status indicator:
+
+| Mode        | Meaning                                                      |
+| ----------- | ------------------------------------------------------------ |
+| `listening` | Default state — the agent is waiting for or hearing the user |
+| `thinking`  | The agent is preparing a response                            |
+| `speaking`  | Agent audio is playing; ends when playback finishes          |
+
+`session.isSpeaking` is a convenience boolean for the `speaking` mode. Mode does not react to the user's own speech — for instant "the mic hears you" feedback, poll `getInputVolume()` locally.
+
+## Send text
+
+Users can type instead of talking, in the same session:
+
+```javascript Text input
+// Send a typed user turn. There is no server echo — the SDK emits
+// the finalized `message` event locally from the text you passed.
+session.sendUserMessage("Do you ship to Norway?");
+
+// Text-only reply for this turn: the agent answers in text
+// (agentResponseDelta / agentResponse) without speaking out loud.
+session.sendUserMessage("What's my order status?", { audio: false });
+
+// Signal typing so the agent doesn't talk over the user.
+input.addEventListener("input", () => session.sendUserActivity());
+
+// Stop the agent's current speech immediately (explicit barge-in).
+session.interrupt();
+```
+
+## Audio controls
+
+| Method / property                                      | Description                                                                                                               |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `setMicMuted(muted)` / `micMuted`                      | Mute or unmute the microphone                                                                                             |
+| `setOutputVolume(v)`                                   | Set playback volume, `0`–`1`                                                                                              |
+| `getInputVolume()` / `getOutputVolume()`               | Current mic / agent volume, `0`–`1` — poll per frame                                                                      |
+| `getInputFrequencyData()` / `getOutputFrequencyData()` | FFT data as `Uint8Array`, for visualizers                                                                                 |
+| `startAudio()`                                         | Unlock playback under browser autoplay policies — call inside a user gesture (for example the click that starts the call) |
+
+Select specific devices at start with the `audio` option (`inputDeviceId` / `outputDeviceId`).
+
+```javascript Audio visualizer
+function draw() {
+  const fft = session.getOutputFrequencyData(); // Uint8Array
+  renderBars(canvas, fft);
+  rafId = requestAnimationFrame(draw);
+}
+draw();
+
+// Stop drawing when the session ends.
+session.on("disconnect", () => cancelAnimationFrame(rafId));
+```
+
+## Client tools
+
+Register handlers for tools of type `client` declared on the agent — the agent calls them mid-conversation and your return value goes back to the model:
+
+```javascript Register a client tool
+const session = await AgentSession.start({
+  agentId: "YOUR_AGENT_ID",
+  clientTools: {
+    open_page: async params => {
+      showPanel(String(params.page));
+      return { opened: true };
+    },
+  },
+});
+
+// Or after start:
+session.registerClientTool("highlight_product", handler);
+```
+
+Handlers can be sync or async; a thrown error or a timeout (default 15 s) is returned to the agent as a tool error. See [Client tools](/agents/build/client-tools) for declaration, naming rules, and dispatch semantics.
+
+## Errors
+
+Failures surface as `FishAgentError` — thrown from `AgentSession.start()` when the session can't be created, emitted on the `error` event otherwise. Each carries a `code`, an optional `statusCode` (set on session-creation HTTP errors), and `cause`.
+
+| Code                                | Meaning                                                                                                                                                                                                                                        |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `session_request_failed`            | Session creation failed — check `statusCode`                                                                                                                                                                                                   |
+| `agent_not_public`                  | `agentId` mode, but the agent is not enabled for public access                                                                                                                                                                                 |
+| `origin_forbidden`                  | The page's origin is not in the agent's allowed origins                                                                                                                                                                                        |
+| `unsupported_transport`             | The session token uses a transport this SDK version doesn't know — upgrade the SDK                                                                                                                                                             |
+| `mic_permission_denied`             | The user denied microphone access; the SDK ends the session                                                                                                                                                                                    |
+| `device_change_failed`              | A requested audio device could not be activated, or the browser doesn't support selecting it (output selection is unsupported on some mobile browsers) — thrown from `start()` with `audio.outputDeviceId` set, or from device-switching calls |
+| `connection_failed`                 | Could not establish the realtime connection                                                                                                                                                                                                    |
+| `session_expired`                   | The session token's join deadline passed before connecting                                                                                                                                                                                     |
+| `tool_failed` / `tool_timeout`      | A client tool handler threw or timed out                                                                                                                                                                                                       |
+| `provider_error` / `internal_error` | The session failed server-side — upstream model/voice provider vs. platform runtime                                                                                                                                                            |
+
+<Note>
+  `provider_error` and `internal_error` carry only the category code — raw
+  provider or infrastructure details are never sent to the browser.
+</Note>
+
+```javascript Handle errors
+try {
+  const session = await AgentSession.start({ agentId: "YOUR_AGENT_ID" });
+  session.on("error", err => console.warn("session error:", err.code));
+} catch (err) {
+  if (err.code === "agent_not_public") showEnableHint();
+  else showRetry(err.code);
+}
+```
+
+## End the session
+
+```javascript Hang up
+await session.end(); // graceful hangup; disconnect fires with reason "user_hangup"
+```
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="React SDK" icon="react" href="/agents/deploy/react-sdk">
+    Hooks, provider, and visualizer components on top of this SDK.
+  </Card>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    Mint session tokens from your backend for private agents.
+  </Card>
+  <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
+    Backend-free sessions with origin allow-lists and rate limits.
+  </Card>
+  <Card
+    title="Wire protocol"
+    icon="tower-broadcast"
+    href="/agents/deploy/protocol"
+  >
+    The wire-level events underneath the SDK.
+  </Card>
+</CardGroup>

--- a/agents/deploy/widget.mdx
+++ b/agents/deploy/widget.mdx
@@ -1,0 +1,171 @@
+---
+title: "Widget"
+description: "Embed a complete voice and chat UI on any website with two lines of HTML — no build step"
+icon: "puzzle-piece"
+---
+
+The widget is the zero-code way to put your agent on a website. A `<fish-agent>` custom element renders the complete experience — a floating launcher that expands into a voice-first chat card with live transcript, typing during the call, and inline tool activity — and a single script tag registers it. Under the hood it runs the same sessions as the [Web SDK](/agents/deploy/web-sdk), so everything downstream (history, analysis, webhooks) works unchanged.
+
+## Prerequisites
+
+- An agent with a [published version](/agents/deploy/versions-publishing).
+- **Public access** enabled on the agent, with your site's origin on the allowed-origins list — see [Public agents](/agents/deploy/public-agents). `localhost` and `127.0.0.1` count as different origins.
+- To keep the agent private instead, skip public access and supply session tokens from your backend with [`sessionTokenProvider`](#private-agents).
+
+## Two-line embed
+
+Add the element and the script anywhere on the page:
+
+```html
+<fish-agent agent-id="your-agent-id"></fish-agent>
+<script
+  src="https://unpkg.com/@fishaudio/agent-widget-embed"
+  async
+  type="text/javascript"
+></script>
+```
+
+`@fishaudio/agent-widget-embed` is the widget pre-bundled as one IIFE file that registers `<fish-agent>` on load.
+
+## Install from npm
+
+Bundlers can install the element instead: `npm install @fishaudio/agent-widget`, then call `registerWidget()` once. Importing the package has no side effects — registration happens only when you call it.
+
+```javascript
+import { registerWidget } from "@fishaudio/agent-widget";
+registerWidget(); // defines <fish-agent>
+```
+
+### React
+
+React apps get a real component: `<FishAgentWidget>` registers and renders the element with camelCase props, object props serialized for you, and the [page events](#page-events) as callback props — `clientTools` is just a prop:
+
+```tsx
+import { FishAgentWidget } from "@fishaudio/agent-widget/react";
+
+<FishAgentWidget
+  agentId="your-agent-id"
+  clientTools={{
+    highlight_product: ({ product_id }) => scrollToProduct(product_id),
+  }}
+  onConnect={({ sessionId }) => console.log(sessionId)}
+/>;
+```
+
+Every attribute below has a camelCase prop; `dynamicVariables` and `textContents` take objects, and `onCall(options)` still runs last for anything else. Importing the entry also types the raw `<fish-agent>` element in JSX, for pages that use the CDN script and install the package only for its types.
+
+## Attributes
+
+| Attribute                                                 | Description                                                                                                                |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `agent-id`                                                | Public agent ID. Required unless the `sessionTokenProvider` property is set — see [Private agents](#private-agents).       |
+| `agent-name`                                              | Display name in the header.                                                                                                |
+| `greeting`                                                | Home-screen headline.                                                                                                      |
+| `proactive-message`                                       | Enables the attention bubble next to the launcher.                                                                         |
+| `proactive-delay`                                         | Seconds before the bubble shows. Default `3`.                                                                              |
+| `transcript` / `text-input` / `mic-muting`                | Feature switches, on by default; set `"false"` to disable.                                                                 |
+| `consent`                                                 | `"true"` shows a first-run terms card (default off). Acceptance is remembered in `localStorage`.                           |
+| `consent-text`, `terms-url`, `privacy-url`, `consent-key` | Consent copy, linked policies, and the `localStorage` key (default `fish-agent-consent`).                                  |
+| `position`                                                | `bottom-right` (default), `bottom-left`, `top-right`, `top-left`.                                                          |
+| `language`                                                | Pin the session language, subject to the agent's override allowlist. See [Voice & language](/agents/build/voice-language). |
+| `dynamic-variables`                                       | JSON object of `{{name}}` template values. See [Dynamic variables](/agents/build/dynamic-variables).                       |
+| `user-id`                                                 | Your end-user identifier, stored on the session.                                                                           |
+| `server-url`                                              | Fish API base override. Default `https://api.fish.audio`.                                                                  |
+| `text-contents`                                           | JSON overriding any UI string (keys in `DEFAULT_TEXTS` of `@fishaudio/agent-widget`).                                      |
+
+## Private agents
+
+Keep the agent non-public and set `sessionTokenProvider` instead of an `agent-id`. It's a JS property on the element (functions can't be attributes), called before every session start: fetch the session token from your backend — with whatever auth headers, payload, or credentials the request needs — and return the JSON; it's used verbatim.
+
+```html
+<fish-agent agent-name="Support"></fish-agent>
+<script>
+  document.querySelector("fish-agent").sessionTokenProvider = async () => {
+    const response = await fetch("/api/voice-session", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${appSession.token}` },
+    });
+    return response.json();
+  };
+</script>
+```
+
+React apps pass the same function as a prop:
+
+```tsx
+<FishAgentWidget sessionTokenProvider={getSessionToken} />
+```
+
+Your backend holds the API key and creates the session with `POST /v1/agent/sessions`; origin checks, user auth, and rate limiting on that endpoint are yours. See [Authentication](/agents/deploy/authentication) for the token flow and a backend example.
+
+## Theming
+
+Set CSS custom properties on the element. The widget's internals live in a shadow root — page CSS can't leak in, but every `--fish-*` token is public:
+
+```css
+fish-agent {
+  --fish-accent: #7c3aed;
+  --fish-orb-color-1: #c4b5fd;
+  --fish-orb-color-2: #4c1d95;
+  --fish-radius: 16px;
+  --fish-offset-x: 32px;
+  --fish-offset-y: 32px;
+  --fish-z-index: 999999;
+}
+```
+
+| Property                                    | Controls                          |
+| ------------------------------------------- | --------------------------------- |
+| `--fish-accent`                             | Launcher and primary button color |
+| `--fish-orb-color-1` / `--fish-orb-color-2` | The voice orb's gradient colors   |
+| `--fish-radius`                             | Corner radius of the panel        |
+| `--fish-offset-x` / `--fish-offset-y`       | Distance from the viewport edges  |
+| `--fish-z-index`                            | Stacking order on your page       |
+
+Also available: `--fish-accent-text`, `--fish-bg`, `--fish-text`, `--fish-text-secondary`, `--fish-border`, `--fish-bubble-agent-bg/-text`, `--fish-bubble-user-bg/-text`, `--fish-danger`, `--fish-live`, `--fish-fab-size`, `--fish-font`.
+
+## Page events
+
+The element dispatches `CustomEvent`s (bubbling, composed):
+
+| Event                   | `detail`                                                 | When                                                                                                   |
+| ----------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `fish-agent:call`       | `{ options }` — **mutable** `AgentSession.start` options | Right before a session starts. Mutate `detail.options` to inject `clientTools`, `overrides`, anything. |
+| `fish-agent:connect`    | `{ sessionId }`                                          | Session established.                                                                                   |
+| `fish-agent:disconnect` | `{ reason }`                                             | Session ended.                                                                                         |
+| `fish-agent:error`      | `{ code, message }`                                      | Start failure or in-call error.                                                                        |
+
+Inbound: dispatch `fish-agent:expand` on the element or `document` to open the panel programmatically.
+
+Registering [client tools](/agents/build/client-tools) is just the `:call` event (React apps pass the `clientTools` prop instead — same injection, wrapped):
+
+```javascript
+document
+  .querySelector("fish-agent")
+  .addEventListener("fish-agent:call", event => {
+    event.detail.options.clientTools = {
+      highlight_product: ({ product_id }) => scrollToProduct(product_id),
+    };
+  });
+```
+
+## Console settings and precedence
+
+On load, the widget anonymously fetches the agent's console widget settings from `GET /v1/agent/agents/{agent_id}/widget` — the same public-plus-origin gate as session creation, so it only answers for public agents to allowed origins. Settings resolve with a fixed precedence: **HTML attribute > console widget config > built-in default**. The endpoint being unreachable never breaks the widget — it renders from attributes and defaults.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
+    The public switch, origin allowlist, and rate limits behind the widget.
+  </Card>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    The session-token flow your `sessionTokenProvider` implements.
+  </Card>
+  <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
+    The `AgentSession` API underneath the widget, for building your own UI.
+  </Card>
+  <Card title="Client tools" icon="code" href="/agents/build/client-tools">
+    Let the agent trigger actions on the embedding page.
+  </Card>
+</CardGroup>

--- a/agents/monitor/conversation-history.mdx
+++ b/agents/monitor/conversation-history.mdx
@@ -1,0 +1,223 @@
+---
+title: "Conversation History"
+description: "List past sessions, replay the full timeline of messages and tool calls, and download recordings"
+icon: "clock-rotate-left"
+---
+
+Every production session your agents handle — from the API, the console, [public agents](/agents/deploy/public-agents), or [phone calls](/agents/telephony/inbound-calls) — is queryable over REST: a lightweight list for browsing, a merged timeline of messages and tool activity per session, and per-speaker recordings when the agent [records audio](#what-gets-stored). You can query a session while the call is still in progress.
+
+This is a server-side API — authenticate with your API key. The client SDKs deliberately expose no history interface; fetch history from your backend and pass it to your frontend as needed.
+
+## What gets stored
+
+The session record — status, timing, caller attribution, name, and `metadata` — and the conversation transcript are always kept for production sessions. Audio recording is a per-agent choice, on by default: set `conversation.record_audio` in the console under your agent's **Settings** or in the `conversation` section of the [config API](/agents/build/configuration#configure-through-the-api), with a per-session override on the [session request](/agents/deploy/authentication). Recording off means there is no audio to download.
+
+The setting doesn't affect the live call: transcript events still stream to connected clients in real time.
+
+<Warning>
+  Recording defaults to on. Call-recording laws vary by jurisdiction — make sure
+  callers are informed and consent where required before going live.
+</Warning>
+
+## List sessions
+
+`GET /v1/agent/sessions` returns session facts, newest first. The list is intentionally thin — no transcripts or tool details — so it stays fast at any volume.
+
+<CodeGroup>
+```bash API (curl)
+curl "https://api.fish.audio/v1/agent/sessions?agent_id=YOUR_AGENT_ID&status=completed&page_size=50" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+```python Python
+import os
+import httpx
+
+resp = httpx.get(
+    "https://api.fish.audio/v1/agent/sessions",
+    params={"agent_id": "YOUR_AGENT_ID", "status": "completed", "page_size": 50},
+    headers={"Authorization": f"Bearer {os.environ['FISH_API_KEY']}"},
+)
+sessions = resp.json()["sessions"]
+```
+
+</CodeGroup>
+
+Each row carries the session facts:
+
+```json
+{
+  "sessions": [
+    {
+      "session_id": "…",
+      "agent_id": "…",
+      "agent_name": "Support agent",
+      "name": "Order #4821 follow-up",
+      "status": "completed",
+      "source": "phone",
+      "caller_number": "+15551234567",
+      "dialed_number": "+14155550100",
+      "started_at": "2026-07-22T09:14:02Z",
+      "ended_at": "2026-07-22T09:16:05Z",
+      "duration_seconds": 123,
+      "metadata": { "crm_ticket": "T-4821" }
+    }
+  ],
+  "has_more": true,
+  "next_cursor": "…"
+}
+```
+
+`caller_number` and `dialed_number` are set for phone sessions only (E.164) and are `null` for web sessions. `name` is the display name you passed when creating the session (`null` when omitted), and `metadata` echoes back whatever you attached when creating the session.
+
+### Filters
+
+| Parameter                          | Behavior                                                                                              |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `agent_id`                         | Sessions of a single agent                                                                            |
+| `status`                           | One of `pending`, `active`, `completed`, `failed`, `unknown` — comma-separate values to match several |
+| `caller_number`                    | Exact match on the caller's E.164 number; a bare number gets `+` prepended automatically              |
+| `created_after` / `created_before` | ISO 8601 timestamps                                                                                   |
+
+<Note>
+  `pending` sessions — a session was created but no participant ever connected —
+  are excluded by default. Pass `status=pending` explicitly to see them. Preview
+  calls made from the Builder never appear in this API.
+</Note>
+
+### Pagination
+
+Two modes, mutually exclusive (combining them returns `400`):
+
+| Mode   | How                                                                                     | Use it for                  |
+| ------ | --------------------------------------------------------------------------------------- | --------------------------- |
+| Cursor | Pass the previous response's `next_cursor` as `cursor`; stop when `has_more` is `false` | Crawling, exports, syncing  |
+| Page   | Pass `page` (1-based); the response always includes `total`                             | Paged UIs with jump-to-page |
+
+`page_size` defaults to 30, maximum 100; values out of range are rejected. In cursor mode `total` is `null` unless you pass `include_total=true`. Page mode is capped at an offset of 100,000 rows — requests beyond it return `400` — and every page response still includes `next_cursor`, so you can switch to cursor crawling from any page for deep scans.
+
+## Get a session
+
+`GET /v1/agent/sessions/{session_id}` returns the session facts plus a single `items` timeline: messages and tool activity merged in the order they actually happened.
+
+```bash API (curl)
+curl "https://api.fish.audio/v1/agent/sessions/SESSION_ID" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+```json
+{
+  "session_id": "…",
+  "status": "completed",
+  "items": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": "Can you check order A1?",
+      "turn_id": 3,
+      "created_at": "2026-07-22T09:14:05Z"
+    },
+    {
+      "type": "tool_call",
+      "call_id": "tool_8f2…",
+      "tool_name": "lookup_order",
+      "tool_source": "webhook",
+      "input": "{\"order_id\":\"A1\"}",
+      "created_at": "2026-07-22T09:14:06Z"
+    },
+    {
+      "type": "tool_result",
+      "call_id": "tool_8f2…",
+      "tool_name": "lookup_order",
+      "tool_source": "webhook",
+      "status": "completed",
+      "output": "{\"state\":\"shipped\"}",
+      "output_truncated": false,
+      "error": null,
+      "latency_ms": 812,
+      "created_at": "2026-07-22T09:14:07Z"
+    },
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": "Order A1 shipped yesterday.",
+      "turn_id": 3,
+      "created_at": "2026-07-22T09:14:07Z"
+    }
+  ],
+  "analysis": {
+    "status": "completed",
+    "summary": "…",
+    "data": [],
+    "criteria_results": []
+  }
+}
+```
+
+### Item types
+
+| `type`        | What it is                                                                                                                                                 |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `message`     | One utterance. `role` is `user` or `assistant` (system prompt content is never exposed). `turn_id` groups items belonging to the same conversational turn. |
+| `tool_call`   | A tool invocation as it started. `input` is a JSON string, stored in full — no truncation.                                                                 |
+| `tool_result` | The paired outcome, matched by `call_id`. `status` is `completed` or `failed`. `latency_ms` is the execution time.                                         |
+
+Details worth knowing:
+
+- **Role vocabulary** — the history API's `assistant` is the same speaker the [SDK's live events](/agents/deploy/web-sdk) call `agent`.
+- **Order** — items are sorted by `created_at` ascending; a `tool_result`'s timestamp is its completion time, so long-running tools appear where they actually finished, with messages in between. Items sharing a timestamp order `message`, then `tool_call`, then `tool_result`.
+- **`tool_source`** — where the tool ran: `client`, `webhook`, `builtin` (platform tools such as call transfer and hang-up), `mcp` (tools from a connected MCP server), `background` (work the agent delegated to a background task), or `unknown` (calls recorded before source attribution). Treat it as an open set. See [Tools](/agents/build/tools).
+- **Payloads** — `input` and `output` are JSON strings, symmetric with the live SDK events, so one parser covers both. `output` and `error` are stored up to 256 KB; beyond that the text is cut and `output_truncated` is `true`.
+- **Mid-call queries** — you can fetch an `active` session; you get the items persisted so far, and `analysis` is `null` until [post-call analysis](/agents/monitor/post-call-analysis) completes.
+- A `tool_call` without a matching `tool_result` means the execution never resolved.
+
+<Warning>
+  `items` is a discriminated union on `type`, and it evolves additively. Ignore
+  item types and fields you don't recognize — new modalities and item kinds will
+  appear without a version bump.
+</Warning>
+
+### Correlate with live events
+
+`call_id` is the same identifier your client receives in the SDK's `toolCallStarted` / `toolCallCompleted` / `toolCallFailed` events. Log it live, and you can align in-call UI with the post-call record — jump from a tool chip in your interface straight to the matching `tool_call` / `tool_result` pair in history. See the [Web SDK](/agents/deploy/web-sdk).
+
+## Download recordings
+
+`GET /v1/agent/sessions/{session_id}/recording` returns the recording status and signed download URLs — one audio track per speaker, so you can play or process the agent and the user separately. Recordings exist only when the session was [recorded](#what-gets-stored): for sessions that never recorded — recording turned off, or no audio produced — the endpoint returns `404`.
+
+```bash API (curl)
+curl "https://api.fish.audio/v1/agent/sessions/SESSION_ID/recording" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+Signed URLs are short-lived. Don't store them — store the `session_id` and request fresh URLs when you need the audio. For the same reason, recordings are not embedded in the session detail response.
+
+## Access semantics
+
+- Your API key sees every production session across your team's workspaces, from all sources.
+- A session that doesn't exist — or belongs to another team — always returns `404`, never `403`. The [recording endpoint](#download-recordings) additionally returns `404` for a session that exists but was never recorded.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card
+    title="Post-call analysis"
+    icon="wand-magic-sparkles"
+    href="/agents/monitor/post-call-analysis"
+  >
+    What the embedded `analysis` object contains and how to configure it.
+  </Card>
+  <Card title="Webhooks" icon="webhook" href="/agents/monitor/webhooks">
+    Push instead of poll — get notified when sessions end.
+  </Card>
+  <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
+    The live `toolCall*` events that share `call_id` with history.
+  </Card>
+  <Card
+    title="Inbound calls"
+    icon="phone"
+    href="/agents/telephony/inbound-calls"
+  >
+    Where `caller_number` and `dialed_number` come from.
+  </Card>
+</CardGroup>

--- a/agents/monitor/post-call-analysis.mdx
+++ b/agents/monitor/post-call-analysis.mdx
@@ -1,0 +1,201 @@
+---
+title: "Post-call Analysis"
+description: "Automatic summaries, structured data extraction, and success evaluation after every conversation"
+icon: "chart-simple"
+---
+
+After a conversation ends, the platform runs an LLM pass over the [stored transcript](/agents/monitor/conversation-history#what-gets-stored) and produces three results: a **summary**, values for the **data fields** you define, and a verdict for each **success criterion**. Summaries are on by default for every agent — extraction and evaluation are opt-in, configured per agent on the Builder's **Analysis** page.
+
+<CardGroup cols={3}>
+  <Card
+    title="See it on a test call"
+    icon="phone"
+    href="/agents/test/preview-calls"
+  >
+    End a preview call and watch the analysis card fill in.
+  </Card>
+  <Card
+    title="Read results via API"
+    icon="brackets-curly"
+    href="/agents/monitor/conversation-history"
+  >
+    Analysis is embedded in every session detail response.
+  </Card>
+  <Card
+    title="Push to your backend"
+    icon="webhook"
+    href="/agents/monitor/webhooks"
+  >
+    Get notified the moment a conversation is analyzed.
+  </Card>
+</CardGroup>
+
+## What a run produces
+
+### Summary
+
+A concise recap of the conversation. Enabled by default — every conversation gets one out of the box.
+
+- **Custom prompt** (optional, up to 1,000 characters) — replace the platform's default summary instruction with your own, e.g. "Summarize in two sentences, focusing on the caller's request and the outcome."
+- **Output language** — fixed per agent, chosen from 10 locales (English, Chinese, Japanese, Korean, Spanish, French, German, Portuguese, Russian, Arabic). Default is English.
+
+<Note>
+  The summary language does **not** follow the conversation language. Summaries
+  and rationales are always written in the configured language, even when the
+  conversation happened in another one — so downstream systems see consistent
+  output.
+</Note>
+
+### Data fields
+
+Structured values extracted from the transcript — up to **20 fields** per agent. Each field is:
+
+| Property       | Description                                                                                                |
+| -------------- | ---------------------------------------------------------------------------------------------------------- |
+| `name`         | Unique per agent; lowercase letters, digits, and underscores, starting with a letter (up to 64 characters) |
+| `type`         | `boolean`, `text`, `number`, or `enum`                                                                     |
+| `description`  | Instruction telling the model what to extract (up to 500 characters)                                       |
+| `enum_options` | For `enum` fields only: 2–20 allowed values                                                                |
+
+When the conversation doesn't contain the information, the field's value is `null` with a rationale explaining why — the model never guesses.
+
+### Success criteria
+
+Up to **10 criteria** per agent, each a `name` plus a `description` (up to 500 characters) stating what a successful conversation looks like — "The agent resolved the caller's issue or set clear next steps."
+
+Every criterion gets a three-state verdict with a rationale:
+
+- **`success`** — the transcript shows the expectation was met.
+- **`failure`** — the transcript shows it was not.
+- **`unknown`** — the transcript is incomplete, the answer was ambiguous, or the information needed to judge is missing.
+
+<Tip>
+  The `unknown` state is deliberate: rather than forcing an ambiguous call into
+  a binary verdict, the model tells you it couldn't judge — so your success-rate
+  numbers stay honest.
+</Tip>
+
+## Configure analysis
+
+Open your agent's **Analysis** page in the Builder. Three cards — Summary, Data fields, and Criteria — autosave to the draft as you edit. You can also set the `analysis` section of the configuration via the API:
+
+```bash
+curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "analysis": {
+      "summary": { "enabled": true, "language": "en" },
+      "data_fields": [
+        {
+          "name": "callback_requested",
+          "type": "boolean",
+          "description": "Did the caller ask to be called back?"
+        },
+        {
+          "name": "issue_category",
+          "type": "enum",
+          "description": "The main topic of the call.",
+          "enum_options": ["billing", "shipping", "product", "other"]
+        }
+      ],
+      "criteria": [
+        {
+          "name": "issue_resolved",
+          "description": "The agent fully resolved the caller'\''s issue, or set clear next steps before the call ended."
+        }
+      ]
+    }
+  }'
+```
+
+Like all configuration, edits land in the [draft](/agents/deploy/versions-publishing). Preview calls use the draft immediately; production sessions pick up analysis changes after you **publish**.
+
+To disable analysis entirely, turn the summary off and leave both lists empty — conversations then finish with analysis status `skipped` and no LLM call is made.
+
+## When analysis runs
+
+Analysis starts automatically when a conversation ends — production sessions from any source, and preview calls when you end them. A run moves through these statuses:
+
+| Status      | Meaning                                                                             |
+| ----------- | ----------------------------------------------------------------------------------- |
+| `queued`    | Scheduled, waiting to run                                                           |
+| `running`   | The LLM pass is in progress                                                         |
+| `completed` | Results are available                                                               |
+| `skipped`   | Nothing to analyze — the conversation had no user messages, or analysis is disabled |
+| `error`     | The run failed; no results                                                          |
+
+Results are typically ready within seconds of the conversation ending.
+
+<Note>
+  Production sessions are analyzed against the agent version pinned when the
+  session started — editing your criteria afterwards never changes how past
+  conversations were judged, and each result stays attributable to the
+  configuration that produced it.
+</Note>
+
+## Read the results
+
+In the Builder, analysis appears in the call panel after a preview call ends. Programmatically, the [session detail](/agents/monitor/conversation-history) response embeds it under `analysis`:
+
+```bash
+curl "https://api.fish.audio/v1/agent/sessions/$SESSION_ID" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+```json
+{
+  "analysis": {
+    "status": "completed",
+    "summary": "The caller reported a delayed order and asked for a refund. The agent confirmed the delay, issued the refund, and offered a discount on the next purchase.",
+    "data": [
+      {
+        "name": "callback_requested",
+        "type": "boolean",
+        "value": false,
+        "rationale": "The caller did not ask to be called back."
+      },
+      {
+        "name": "issue_category",
+        "type": "enum",
+        "value": "shipping",
+        "rationale": "The conversation centered on a delayed delivery."
+      }
+    ],
+    "criteria_results": [
+      {
+        "name": "issue_resolved",
+        "result": "success",
+        "rationale": "The refund was issued and the caller confirmed they were satisfied."
+      }
+    ]
+  }
+}
+```
+
+To push results into your CRM or data warehouse as soon as they're ready, configure a [post-call webhook](/agents/monitor/webhooks) — it fires once analysis completes.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card
+    title="Conversation history"
+    icon="clock-rotate-left"
+    href="/agents/monitor/conversation-history"
+  >
+    Retrieve stored transcripts and session details over REST.
+  </Card>
+  <Card title="Webhooks" icon="webhook" href="/agents/monitor/webhooks">
+    Deliver analysis results to your systems automatically.
+  </Card>
+  <Card title="Preview calls" icon="phone" href="/agents/test/preview-calls">
+    Iterate on fields and criteria with instant feedback after each test call.
+  </Card>
+  <Card
+    title="Versions & publishing"
+    icon="code-branch"
+    href="/agents/deploy/versions-publishing"
+  >
+    How draft edits roll out to production sessions.
+  </Card>
+</CardGroup>

--- a/agents/monitor/webhooks.mdx
+++ b/agents/monitor/webhooks.mdx
@@ -1,0 +1,404 @@
+---
+title: "Webhooks"
+description: "Get an HTTP POST when a call ends and when its analysis completes — no polling"
+icon: "bell"
+---
+
+Point your agent at one or more endpoints on your server and Fish Audio calls them when things happen: `call.ended` the moment a session reaches a terminal state, `call.analyzed` when [post-call analysis](/agents/monitor/post-call-analysis) finishes. Use them to write results into your CRM, ticketing system, or data warehouse without polling the sessions API.
+
+## Events
+
+| Event           | Fires                                                                                            | Payload                                       |
+| --------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| `call.ended`    | When a session reaches a terminal state — every real call, whether or not analysis is configured | Session facts plus the reason the call ended  |
+| `call.analyzed` | When post-call analysis completes                                                                | Session facts plus the full `analysis` entity |
+
+For a given session, `call.ended` is always delivered before `call.analyzed`. `call.analyzed` is sent only when analysis actually completes — calls where analysis is skipped (no user speech or analysis disabled) or fails produce `call.ended` only.
+
+<Note>
+  Transcripts are deliberately excluded from webhook payloads — fetch them on
+  demand with `GET /v1/agent/sessions/{session_id}`. See [conversation
+  history](/agents/monitor/conversation-history).
+</Note>
+
+## Configure the endpoint
+
+Webhooks live in the `webhooks` section of your agent's configuration. `post_call` is a list, so one agent can fan events out to several systems at once. Set them in the console on your agent's **Webhooks** page, or via the config API:
+
+<CodeGroup>
+```bash API (curl)
+curl --request PATCH https://api.fish.audio/v1/agent/agents/YOUR_AGENT_ID/config \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "webhooks": {
+      "post_call": [
+        {
+          "url": "https://example.com/fish-webhooks",
+          "secret": "your-signing-secret"
+        },
+        {
+          "url": "https://crm.example.com/fish-webhooks",
+          "secret": "another-signing-secret"
+        }
+      ]
+    }
+  }'
+```
+
+```python Python
+import httpx, os
+
+httpx.patch(
+    "https://api.fish.audio/v1/agent/agents/YOUR_AGENT_ID/config",
+    headers={"Authorization": f"Bearer {os.environ['FISH_API_KEY']}"},
+    json={
+        "webhooks": {
+            "post_call": [
+                {
+                    "url": "https://example.com/fish-webhooks",
+                    "secret": "your-signing-secret",
+                },
+                {
+                    "url": "https://crm.example.com/fish-webhooks",
+                    "secret": "another-signing-secret",
+                },
+            ]
+        }
+    },
+)
+```
+
+</CodeGroup>
+
+The list is replaced as a whole on each update — send every endpoint you want to keep, including the ones you aren't changing. Set it to `null` or `[]` to stop deliveries. A single `post_call` object is still accepted and is treated as a one-element list.
+
+| Field       | Rules                                                                                                                                                                                       |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `post_call` | Up to 5 entries, and their `url` values must be unique — a longer list or a repeated URL is rejected with `422`                                                                             |
+| `url`       | Required on every entry. Up to 4000 characters. Must resolve to a public address — localhost and private-network hosts are rejected with `422`, and the check is repeated at every delivery |
+| `secret`    | Optional signing key, up to 256 characters, set per entry. **Write-only**: reads return `has_secret: true`, never the value                                                                 |
+
+<Note>
+  Webhook settings are part of the agent configuration, so they follow the
+  draft-and-publish flow — [publish](/agents/deploy/versions-publishing) for
+  changes to apply to production calls.
+</Note>
+
+## Payload
+
+Every payload carries the `event` name and a `session` object with a fixed set of session facts. Note the field names differ from the [sessions API](/agents/monitor/conversation-history), which uses `session_id` / `started_at` / `ended_at` for the same facts. `call.ended` adds `ended_reason`; `call.analyzed` adds the `analysis` entity:
+
+<CodeGroup>
+
+```json call.ended
+{
+  "event": "call.ended",
+  "session": {
+    "id": "5f3e…",
+    "agent_id": "a1b2…",
+    "branch_id": "b7d4…",
+    "source": "phone",
+    "status": "completed",
+    "conversation_started_at": "2026-07-23T12:01:12Z",
+    "conversation_ended_at": "2026-07-23T12:04:16Z",
+    "duration_seconds": 184,
+    "end_user_id": "customer-42",
+    "metadata": { "order_ref": "SO-1042" },
+    "agent_name": "Support agent",
+    "config_hash": "sha256:9c41…"
+  },
+  "ended_reason": "hangup"
+}
+```
+
+```json call.analyzed
+{
+  "event": "call.analyzed",
+  "session": {
+    "id": "5f3e…",
+    "agent_id": "a1b2…",
+    "branch_id": "b7d4…",
+    "source": "phone",
+    "status": "completed",
+    "conversation_started_at": "2026-07-23T12:01:12Z",
+    "conversation_ended_at": "2026-07-23T12:04:16Z",
+    "duration_seconds": 184,
+    "end_user_id": "customer-42",
+    "metadata": { "order_ref": "SO-1042" },
+    "agent_name": "Support agent",
+    "config_hash": "sha256:9c41…"
+  },
+  "analysis": {
+    "status": "completed",
+    "summary": "Caller asked about a delayed order and accepted a reshipment.",
+    "data": [
+      {
+        "name": "callback_requested",
+        "type": "boolean",
+        "value": false,
+        "rationale": "…"
+      }
+    ],
+    "criteria_results": [
+      { "name": "issue_resolved", "result": "success", "rationale": "…" }
+    ]
+  }
+}
+```
+
+</CodeGroup>
+
+`ended_reason` is `hangup` for a call that terminated normally and `error` when the session failed. New values may be added as richer end causes ship — treat unrecognized values as informational rather than rejecting the event.
+
+`end_user_id` and `metadata` are echoed exactly as you set them when creating the session — use them to correlate the event with records in your own system. `branch_id` is an internal configuration-lineage identifier — safe to ignore. What lands in `summary`, `data`, and `criteria_results` is defined by your [analysis configuration](/agents/monitor/post-call-analysis).
+
+## Verify the signature
+
+When an entry has a `secret`, every request to that endpoint carries a signature header with the send time and an HMAC-SHA256 of `{timestamp}.{raw_body}`, keyed with that entry's own secret:
+
+```http
+X-Fish-Webhook-Signature: t=1784808000,v1=8693a4b9…
+```
+
+`t` is the Unix time (seconds) the request was sent — each retry is signed fresh. `v1` is the hex HMAC. Verify in three steps:
+
+1. Parse `t` and `v1` from the header.
+2. Recompute HMAC-SHA256 over the string `{t}.` followed by the **raw request body bytes** — before any JSON parsing or re-serialization — and compare against `v1` in constant time.
+3. Reject requests whose `t` is more than 5 minutes from your clock. Because the timestamp is inside the MAC, a replayed capture can't be refreshed.
+
+<CodeGroup>
+
+```javascript Node.js
+import crypto from "node:crypto";
+
+const TOLERANCE_SECONDS = 300;
+
+function verifyWebhook(rawBody, signatureHeader, secret) {
+  const elements = new Map(
+    (signatureHeader ?? "").split(",").map(el => el.split("=", 2))
+  );
+  const timestamp = elements.get("t");
+  const signature = elements.get("v1");
+  if (
+    !/^\d+$/.test(timestamp ?? "") ||
+    !/^[0-9a-f]{64}$/.test(signature ?? "")
+  ) {
+    return false;
+  }
+  if (Math.abs(Date.now() / 1000 - Number(timestamp)) > TOLERANCE_SECONDS) {
+    return false;
+  }
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(`${timestamp}.`)
+    .update(rawBody)
+    .digest("hex");
+  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+}
+```
+
+```python Python
+import hashlib
+import hmac
+import time
+
+TOLERANCE_SECONDS = 300
+
+def verify_webhook(raw_body: bytes, signature_header: str, secret: str) -> bool:
+    elements = dict(
+        el.split("=", 1) for el in (signature_header or "").split(",") if "=" in el
+    )
+    timestamp = elements.get("t", "")
+    signature = elements.get("v1", "")
+    if not timestamp.isdigit():
+        return False
+    if abs(time.time() - int(timestamp)) > TOLERANCE_SECONDS:
+        return False
+    signed = f"{timestamp}.".encode() + raw_body
+    expected = hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(signature.encode(), expected.encode())
+```
+
+</CodeGroup>
+
+<Warning>
+  Reject requests with a missing or invalid signature. Without verification,
+  anyone who discovers your endpoint URL can forge call results.
+</Warning>
+
+<Note>
+  Future scheme revisions would ship under a new element (`v2=…`) alongside `v1`
+  — parse the elements you know and ignore the rest, as the snippets above do.
+</Note>
+
+## Delivery semantics
+
+| Property  | Behavior                                                                                                          |
+| --------- | ----------------------------------------------------------------------------------------------------------------- |
+| Fan-out   | Every configured endpoint receives every event                                                                    |
+| Guarantee | At-least-once, per endpoint                                                                                       |
+| Timeout   | 10 seconds per attempt                                                                                            |
+| Retries   | 2 after the first attempt (3 attempts total) per endpoint, with backoff of 1s / 5s, then that delivery is dropped |
+| Ordering  | `call.ended` before `call.analyzed` for the same session                                                          |
+
+Endpoints are delivered in parallel and independently: each gets its own attempts, its own retry budget, and its own signature keyed with its own secret. An endpoint that is down and exhausts all three attempts has no effect on the others.
+
+Respond with a `2xx` status within the timeout; a `500` response or a timed-out request counts as a failed attempt. Acknowledge first and process asynchronously — slow handlers burn their own retry budget.
+
+**Idempotency.** At-least-once delivery means the same event can arrive more than once. Each session produces at most one `call.ended` and one `call.analyzed` per endpoint, so dedupe on the pair (`event`, `session.id`) before writing to downstream systems.
+
+<Note>
+  [Preview calls](/agents/test/preview-calls) made from the Builder never
+  trigger webhooks — debugging sessions don't reach your production endpoint. To
+  test end to end, run a real session against your published agent.
+</Note>
+
+## Auto-ticket unresolved calls
+
+`call.analyzed` closes the loop on conversations the agent couldn't: judge every call with a success criterion, and open a ticket in your helpdesk whenever the verdict isn't `success` — no mid-call decision, no dashboard watching.
+
+First give the agent's [analysis configuration](/agents/monitor/post-call-analysis) a criterion that captures resolution:
+
+```json analysis.criteria
+[
+  {
+    "name": "issue_resolved",
+    "description": "The agent fully resolved the caller's issue, or set clear next steps before the call ended."
+  }
+]
+```
+
+Then add your endpoint to `webhooks.post_call` (see [Configure the endpoint](#configure-the-endpoint)) and act on the verdict:
+
+<CodeGroup>
+
+```javascript Node.js (Express)
+import express from "express";
+
+const app = express();
+const seen = new Set(); // swap for your database
+
+app.post(
+  "/fish-webhooks",
+  express.raw({ type: "application/json" }),
+  (req, res) => {
+    const signature = req.get("X-Fish-Webhook-Signature");
+    if (!verifyWebhook(req.body, signature, process.env.FISH_WEBHOOK_SECRET)) {
+      return res.status(401).end();
+    }
+    res.status(200).end(); // acknowledge first, then process
+
+    const payload = JSON.parse(req.body);
+    if (payload.event !== "call.analyzed") return;
+
+    const key = `${payload.event}:${payload.session.id}`;
+    if (seen.has(key)) return; // at-least-once delivery: dedupe
+    seen.add(key);
+
+    const verdict = payload.analysis.criteria_results.find(
+      c => c.name === "issue_resolved"
+    );
+    if (!verdict || verdict.result === "success") return;
+
+    openTicket({
+      subject: `Unresolved call ${payload.session.id}`,
+      body:
+        `${payload.analysis.summary}\n\n` +
+        `issue_resolved: ${verdict.result} — ${verdict.rationale}`,
+      customer: payload.session.end_user_id,
+    });
+  }
+);
+```
+
+```python Python (FastAPI)
+import json
+import os
+
+from fastapi import FastAPI, Header, Request, Response
+
+app = FastAPI()
+seen: set[str] = set()  # swap for your database
+
+@app.post("/fish-webhooks")
+async def fish_webhooks(
+    request: Request,
+    x_fish_webhook_signature: str | None = Header(None),
+):
+    raw = await request.body()
+    secret = os.environ["FISH_WEBHOOK_SECRET"]
+    if not verify_webhook(raw, x_fish_webhook_signature, secret):
+        return Response(status_code=401)
+
+    payload = json.loads(raw)
+    if payload["event"] != "call.analyzed":
+        return {}
+
+    key = f"{payload['event']}:{payload['session']['id']}"
+    if key in seen:  # at-least-once delivery: dedupe
+        return {}
+    seen.add(key)
+
+    results = payload["analysis"]["criteria_results"]
+    verdict = next((c for c in results if c["name"] == "issue_resolved"), None)
+    if verdict and verdict["result"] != "success":
+        open_ticket(
+            subject=f"Unresolved call {payload['session']['id']}",
+            body=f"{payload['analysis']['summary']}\n\n"
+            f"issue_resolved: {verdict['result']} — {verdict['rationale']}",
+            customer=payload["session"]["end_user_id"],
+        )
+    return {}
+```
+
+</CodeGroup>
+
+`verifyWebhook` is the function from [Verify the signature](#verify-the-signature); `openTicket` stands in for your helpdesk's API. Escalating on anything but `success` includes `unknown` verdicts — the model couldn't judge the call, which usually deserves human eyes too. Tighten the check to `failure` only if unknowns prove noisy.
+
+Edges worth handling:
+
+- Calls with nothing to analyze never produce `call.analyzed` (see [Events](#events)). If every call must reach the helpdesk regardless of analysis, watch `call.ended` too.
+- Payloads carry no transcript. To include one in the ticket, fetch `GET /v1/agent/sessions/{session_id}` from your handler — see [conversation history](/agents/monitor/conversation-history).
+- Set `end_user_id` and `metadata` when creating sessions so tickets attach to the right customer record without a lookup.
+
+<Note>
+  Post-call ticketing is silent — the caller has already hung up. When the
+  caller should leave the call holding a ticket number, have the agent open it
+  mid-call with a [webhook
+  tool](/agents/build/webhook-tools#escalate-to-a-ticket-mid-call), and keep
+  this recipe as the safety net behind it.
+</Note>
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card
+    title="Post-call analysis"
+    icon="chart-simple"
+    href="/agents/monitor/post-call-analysis"
+  >
+    Define the summary, data fields, and criteria that `call.analyzed` delivers.
+  </Card>
+  <Card
+    title="Conversation history"
+    icon="clock-rotate-left"
+    href="/agents/monitor/conversation-history"
+  >
+    Fetch the transcript, tool timeline, and recordings by `session_id`.
+  </Card>
+  <Card
+    title="Versions & publishing"
+    icon="code-branch"
+    href="/agents/deploy/versions-publishing"
+  >
+    How configuration changes — including webhooks — go live.
+  </Card>
+  <Card
+    title="Agent configuration"
+    icon="sliders"
+    href="/agents/build/configuration"
+  >
+    The full config schema behind `PATCH /v1/agent/agents/{agent_id}/config`.
+  </Card>
+</CardGroup>

--- a/agents/overview.mdx
+++ b/agents/overview.mdx
@@ -1,0 +1,124 @@
+---
+title: "Agents Overview"
+sidebarTitle: "Overview"
+description: "Build voice agents in the console, ship them with the REST API and SDKs, and put them on the phone"
+icon: "robot"
+---
+
+Fish Agents is a hosted platform for real-time voice agents. Define an agent's prompt, voice, knowledge, and tools in the Builder console, publish it, and talk to it — from your web app through the SDK, over a phone number, or anywhere the REST API reaches. Speech recognition, turn-taking, and speech synthesis are handled for you.
+
+<CardGroup cols={3}>
+  <Card title="Quickstart" icon="rocket" href="/agents/quickstart">
+    Create an agent and have your first conversation in minutes.
+  </Card>
+  <Card title="Concepts" icon="lightbulb" href="/agents/concepts">
+    Agents, drafts, versions, sessions — the mental model.
+  </Card>
+  <Card title="Integration overview" icon="plug" href="/agents/deploy/overview">
+    Pick the right surface for your app.
+  </Card>
+</CardGroup>
+
+## Three surfaces, one agent
+
+| Surface         | What it does                                                                                            | Start here                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Console**     | Design, test, and publish agents visually — no code.                                                    | [Configuration](/agents/build/configuration)    |
+| **REST API**    | Manage agents, sessions, tools, and knowledge programmatically under `/v1/agent/*`.                     | [Authentication](/agents/deploy/authentication) |
+| **Client SDKs** | Run live voice conversations in the browser with `@fishaudio/agent-client` or `@fishaudio/agent-react`. | [Web SDK](/agents/deploy/web-sdk)               |
+
+All three operate on the same agents. The core console workflow — creating agents, editing configuration, publishing versions — is also available over the API with your standard Fish Audio API key:
+
+```bash
+curl https://api.fish.audio/v1/agent/agents \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+## From draft to production
+
+<Steps>
+  <Step title="Configure">
+    Write the system prompt, set the first message, and pick a [voice and
+    speaking language](/agents/build/voice-language). Attach [knowledge
+    sources](/agents/build/knowledge-base) and [tools](/agents/build/tools).
+    Edits save to the agent's draft automatically.
+  </Step>
+  <Step title="Test">
+    Talk to the draft in a [preview call](/agents/test/preview-calls), or run
+    scripted [agent tests](/agents/test/agent-tests) that judge each reply pass
+    or fail.
+  </Step>
+  <Step title="Publish">
+    [Publishing](/agents/deploy/versions-publishing) freezes the draft into an
+    immutable, numbered version. Live sessions always run the published
+    configuration, so you can keep editing safely.
+  </Step>
+  <Step title="Integrate">
+    Drop the [web SDK](/agents/deploy/web-sdk) into your app, create sessions
+    over [REST](/agents/deploy/overview), or [bind a phone
+    number](/agents/telephony/phone-numbers) so the agent answers inbound calls.
+  </Step>
+  <Step title="Monitor">
+    Review transcripts, tool calls, and recordings in [conversation
+    history](/agents/monitor/conversation-history), let [post-call
+    analysis](/agents/monitor/post-call-analysis) summarize and evaluate every
+    call, and push results to your backend with
+    [webhooks](/agents/monitor/webhooks).
+  </Step>
+</Steps>
+
+## Capabilities
+
+<CardGroup cols={2}>
+  <Card
+    title="Prompt & voice"
+    icon="sliders"
+    href="/agents/build/configuration"
+  >
+    System prompt, first message, and any voice from the Fish Audio Voice
+    Library.
+  </Card>
+  <Card title="Knowledge base" icon="book" href="/agents/build/knowledge-base">
+    Upload documents the agent retrieves from during conversations. Update a
+    source and every agent using it picks up the new content.
+  </Card>
+  <Card title="Tools" icon="wrench" href="/agents/build/tools">
+    Call your backend with [webhook tools](/agents/build/webhook-tools), run
+    code in your app with [client tools](/agents/build/client-tools), and toggle
+    built-in [system tools](/agents/build/system-tools).
+  </Card>
+  <Card
+    title="Dynamic variables"
+    icon="brackets-curly"
+    href="/agents/build/dynamic-variables"
+  >
+    Personalize each session with values injected at call time.
+  </Card>
+  <Card
+    title="Versions & publishing"
+    icon="code-branch"
+    href="/agents/deploy/versions-publishing"
+  >
+    Draft safely, publish deliberately, and read back the full version history.
+  </Card>
+  <Card title="Telephony" icon="phone" href="/agents/telephony/inbound-calls">
+    Answer [inbound calls](/agents/telephony/inbound-calls) on [phone
+    numbers](/agents/telephony/phone-numbers) bound to your agents.
+  </Card>
+  <Card
+    title="Conversation history"
+    icon="clock-rotate-left"
+    href="/agents/monitor/conversation-history"
+  >
+    Transcripts, tool timelines, and per-speaker recordings — you choose what
+    each agent stores.
+  </Card>
+  <Card
+    title="Post-call analysis & webhooks"
+    icon="chart-simple"
+    href="/agents/monitor/post-call-analysis"
+  >
+    Automatic summaries, structured data extraction, and success criteria —
+    delivered to your systems via [webhooks](/agents/monitor/webhooks).
+  </Card>
+</CardGroup>

--- a/agents/quickstart.mdx
+++ b/agents/quickstart.mdx
@@ -1,0 +1,207 @@
+---
+title: "Quickstart"
+description: "Create a voice agent and have your first conversation in minutes"
+icon: "rocket"
+---
+
+Build a voice agent and talk to it in a few minutes. Use the console for a no-code path, or provision everything over the API and connect from the browser with the SDK.
+
+**Prerequisites**
+
+- A Fish Audio account
+- For the API path: a Fish Audio API key — see [Authentication](/agents/deploy/authentication)
+
+<Tabs>
+  <Tab title="Dashboard">
+    <Steps>
+      <Step title="Create an agent">
+        Go to [Agents](https://fish.audio/app/agents) and click **New agent**. Give it a name — you land in the Builder immediately.
+      </Step>
+      <Step title="Write the system prompt">
+        On the **Configuration** page, write the system prompt that defines who your agent is and how it should behave (up to 4,000 characters). Optionally set a **First message** so the agent opens the conversation.
+
+        Edits save automatically as a draft — there is no Save button.
+      </Step>
+      <Step title="Pick a voice">
+        Choose a voice and a speaking language for your agent. You can pick from the featured voices or browse the full library. See [Voice & language](/agents/build/voice-language) for details.
+      </Step>
+      <Step title="Test it with a preview call">
+        Click **Test call** in the top bar, then **Start call** in the panel. Your browser asks for microphone access, then you talk to the agent directly — with a live transcript, call timer, and mute and hang-up controls in the side panel.
+
+        Preview calls always run against your current draft, so you can iterate on the prompt and immediately hear the difference. See [Preview calls](/agents/test/preview-calls).
+      </Step>
+      <Step title="Publish">
+        Click **Publish** to turn the draft into an immutable version. Published versions are what real sessions connect to — drafts stay private to the Builder.
+
+        You can keep editing the draft afterwards; nothing goes live until you publish again. See [Versions & publishing](/agents/deploy/versions-publishing).
+      </Step>
+    </Steps>
+
+  </Tab>
+  <Tab title="API">
+    <Steps>
+      <Step title="Create an agent">
+        Create the agent and configure it in one call — the `config` section is optional at creation time, and you can update it later with `PATCH /v1/agent/agents/{agent_id}/config`.
+
+        ```bash Create an agent
+        curl --request POST https://api.fish.audio/v1/agent/agents \
+          --header "Authorization: Bearer $FISH_API_KEY" \
+          --header "Content-Type: application/json" \
+          --data '{
+            "name": "Support agent",
+            "config": {
+              "prompt": {
+                "system_prompt": "You are a friendly support agent for Acme. Keep answers short and conversational."
+              },
+              "voice": {
+                "voice_profile_id": "802e3bc2b27e49c2995d23ef70e6ac89"
+              }
+            }
+          }'
+        ```
+
+        The response includes the agent's `agent_id` — use it as `$AGENT_ID` below. `voice_profile_id` accepts any voice model id from the [Voice Library](/features/manage-voices).
+
+        <Note>
+        `system_prompt` is limited to 4,000 characters; longer prompts return `422`.
+        </Note>
+      </Step>
+      <Step title="Publish it">
+        Sessions only run **published** configuration. Creating a session for an agent that has never been published returns `409`.
+
+        ```bash Publish the draft
+        curl --request POST https://api.fish.audio/v1/agent/agents/$AGENT_ID/publish \
+          --header "Authorization: Bearer $FISH_API_KEY"
+        ```
+
+        Each publish creates an immutable version with an auto-incremented `version_number`.
+      </Step>
+      <Step title="Create a session">
+        From your backend, exchange your API key for a short-lived session token. This is the credential the browser uses to join the call — your API key never leaves your server.
+
+        ```bash Create a session
+        curl --request POST https://api.fish.audio/v1/agent/sessions \
+          --header "Authorization: Bearer $FISH_API_KEY" \
+          --header "Content-Type: application/json" \
+          --data '{ "agent_id": "'$AGENT_ID'" }'
+        ```
+
+        ```json Response
+        {
+          "session_id": "...",
+          "expires_at": "2026-07-23T12:34:56Z",
+          "max_duration_seconds": 1800,
+          "transport": "livekit",
+          "livekit_url": "wss://...",
+          "token": "<participant token>"
+        }
+        ```
+
+        Return this response to your frontend as-is — the SDK consumes it unchanged. `expires_at` is the deadline for joining the call.
+      </Step>
+      <Step title="Connect from the browser">
+        Install the client SDK:
+
+        ```bash Install
+        npm install @fishaudio/agent-client
+        ```
+
+        Pass the session token to `AgentSession.start` — the SDK requests the microphone, connects, and streams audio both ways:
+
+        ```typescript Connect and talk
+        import { AgentSession } from "@fishaudio/agent-client";
+
+        // sessionToken: the JSON response from POST /v1/agent/sessions,
+        // fetched from your backend
+        const session = await AgentSession.start({
+          sessionToken,
+          callbacks: {
+            userTranscript: ({ text }) => console.log("You:", text),
+            agentResponse: ({ text }) => console.log("Agent:", text),
+          },
+        });
+
+        // When you are done:
+        await session.end();
+        ```
+
+        Start talking — you hear the agent reply and both sides of the conversation arrive as transcript events. See the [Web SDK](/agents/deploy/web-sdk) for the full event and method surface, or the [React SDK](/agents/deploy/react-sdk) for hooks.
+      </Step>
+      <Step title="Put it together">
+        The whole loop is two files: a backend route that mints the session with your API key, and frontend code that starts the call. Run the server with `FISH_API_KEY` and `AGENT_ID` set, serve the frontend from your app's dev server (Vite, Next — anything that bundles npm imports), and talk.
+
+        <CodeGroup>
+        ```javascript server.mjs
+        import express from "express";
+
+        const app = express();
+
+        app.post("/api/voice-session", async (req, res) => {
+          const upstream = await fetch("https://api.fish.audio/v1/agent/sessions", {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${process.env.FISH_API_KEY}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ agent_id: process.env.AGENT_ID }),
+          });
+          if (!upstream.ok) {
+            return res.status(502).json({ error: "session_unavailable" });
+          }
+          res.json(await upstream.json());
+        });
+
+        app.listen(3001);
+        ```
+
+        ```javascript main.js
+        import { AgentSession } from "@fishaudio/agent-client";
+
+        const sessionToken = await fetch("/api/voice-session", {
+          method: "POST",
+        }).then(r => r.json());
+
+        const session = await AgentSession.start({
+          sessionToken,
+          callbacks: {
+            userTranscript: ({ text }) => console.log("You:", text),
+            agentResponse: ({ text }) => console.log("Agent:", text),
+          },
+        });
+        ```
+        </CodeGroup>
+
+        Every request and response on this path is in the [Agents API reference](/api-reference/endpoint/agent/create-agent-session).
+      </Step>
+    </Steps>
+
+  </Tab>
+</Tabs>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Core concepts" icon="sitemap" href="/agents/concepts">
+    Agents, drafts, versions, and sessions — how the pieces fit together.
+  </Card>
+  <Card title="Web SDK" icon="code" href="/agents/deploy/web-sdk">
+    Events, transcripts, client tools, and audio controls in the browser.
+  </Card>
+  <Card
+    title="Agents API reference"
+    icon="brackets-curly"
+    href="/api-reference/endpoint/agent/create-agent"
+  >
+    Every endpoint with full request and response schemas.
+  </Card>
+  <Card title="Knowledge base" icon="book" href="/agents/build/knowledge-base">
+    Ground your agent in your own documents.
+  </Card>
+  <Card
+    title="Conversation history"
+    icon="clock-rotate-left"
+    href="/agents/monitor/conversation-history"
+  >
+    Review transcripts, tool calls, and recordings.
+  </Card>
+</CardGroup>

--- a/agents/telephony/inbound-calls.mdx
+++ b/agents/telephony/inbound-calls.mdx
@@ -1,0 +1,144 @@
+---
+title: "Inbound Calls"
+description: "Bind an agent to a phone number and it answers every call to that number"
+icon: "phone-arrow-down-left"
+---
+
+Point a phone number at an agent and it picks up every inbound call. Phone calls are ordinary agent sessions: they appear in session history with caller attribution, they are [stored](/agents/monitor/conversation-history#what-gets-stored) and analyzed under the same per-agent settings as any other conversation, and they trigger the same webhooks.
+
+<CardGroup cols={3}>
+  <Card
+    title="Phone numbers"
+    icon="hashtag"
+    href="/agents/telephony/phone-numbers"
+  >
+    Get a number and manage its agent binding.
+  </Card>
+  <Card
+    title="Conversation history"
+    icon="clock-rotate-left"
+    href="/agents/monitor/conversation-history"
+  >
+    Review transcripts, tool calls, and recordings.
+  </Card>
+  <Card title="Webhooks" icon="webhook" href="/agents/monitor/webhooks">
+    Get notified when calls end and analysis completes.
+  </Card>
+</CardGroup>
+
+## Set up inbound calling
+
+<Steps>
+  <Step title="Get a phone number">
+    Add a number to your workspace — see [Phone numbers](/agents/telephony/phone-numbers). Numbers are stored and displayed in E.164 format (for example `+15551234567`).
+  </Step>
+  <Step title="Publish your agent">
+    Calls connect to the agent's published configuration, not the draft. [Publish](/agents/deploy/versions-publishing) before pointing traffic at the number.
+  </Step>
+  <Step title="Bind the agent to the number">
+    Bind in the console, or set `agent_id` on the number via the API:
+
+    <CodeGroup>
+    ```bash Bind an agent
+    curl --request PATCH https://api.fish.audio/v1/agent/phone-numbers/PHONE_NUMBER_ID \
+      --header "Authorization: Bearer $FISH_API_KEY" \
+      --header "Content-Type: application/json" \
+      --data '{ "agent_id": "YOUR_AGENT_ID" }'
+    ```
+
+    ```bash Unbind
+    curl --request PATCH https://api.fish.audio/v1/agent/phone-numbers/PHONE_NUMBER_ID \
+      --header "Authorization: Bearer $FISH_API_KEY" \
+      --header "Content-Type: application/json" \
+      --data '{ "agent_id": null }'
+    ```
+    </CodeGroup>
+
+  </Step>
+</Steps>
+
+<Tip>
+  The number-to-agent binding is resolved on each incoming call, so a rebind
+  takes effect on the next call — useful for moving a number from a staging
+  agent to a production agent.
+</Tip>
+
+## Phone sessions in history
+
+Every answered call becomes a session with `source: "phone"` and two attribution fields:
+
+| Field           | Description                                                                 |
+| --------------- | --------------------------------------------------------------------------- |
+| `caller_number` | The caller's number, E.164. `null` for non-phone sessions.                  |
+| `dialed_number` | The workspace number that was called, E.164. `null` for non-phone sessions. |
+
+List calls with the standard sessions endpoint. The `caller_number` filter is an exact match; bare numbers are automatically prefixed with `+`, so `15551234567` matches `+15551234567`:
+
+```bash
+curl --request GET "https://api.fish.audio/v1/agent/sessions?agent_id=YOUR_AGENT_ID&caller_number=15551234567" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+```json
+{
+  "sessions": [
+    {
+      "session_id": "9c41f0d2e8a34b7f",
+      "agent_id": "YOUR_AGENT_ID",
+      "agent_name": "Support line",
+      "status": "completed",
+      "source": "phone",
+      "caller_number": "+15551234567",
+      "dialed_number": "+14155550100",
+      "created_at": "2026-07-23T09:14:01Z",
+      "started_at": "2026-07-23T09:14:02Z",
+      "ended_at": "2026-07-23T09:16:45Z",
+      "duration_seconds": 163,
+      "metadata": {}
+    }
+  ],
+  "has_more": false,
+  "next_cursor": null
+}
+```
+
+You can combine `caller_number` with the other list filters (`agent_id`, `status`, `created_after`, `created_before`) — see [Conversation history](/agents/monitor/conversation-history) for the full parameter list.
+
+## Phone sessions behave like any session
+
+Nothing about a phone call needs special handling downstream:
+
+- **Transcript and tool timeline** — `GET /v1/agent/sessions/{session_id}` returns the conversation, including tool calls and results, when the agent [stores transcripts](/agents/monitor/conversation-history#what-gets-stored). See [Conversation history](/agents/monitor/conversation-history).
+- **Recording** — `GET /v1/agent/sessions/{session_id}/recording` returns signed URLs, one track per speaker, when the session was recorded.
+- **Post-call analysis** — summaries, data fields, and evaluation criteria run on phone sessions like any other. See [Post-call analysis](/agents/monitor/post-call-analysis).
+- **Webhooks** — `call.ended` and `call.analyzed` fire for phone sessions too. See [Webhooks](/agents/monitor/webhooks).
+- **Hang up via API** — end an in-progress call with `POST /v1/agent/sessions/{session_id}/end`.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card
+    title="Phone numbers"
+    icon="hashtag"
+    href="/agents/telephony/phone-numbers"
+  >
+    Number management and agent bindings.
+  </Card>
+  <Card
+    title="Versions & publishing"
+    icon="code-branch"
+    href="/agents/deploy/versions-publishing"
+  >
+    Control which configuration answers your calls.
+  </Card>
+  <Card
+    title="Post-call analysis"
+    icon="chart-simple"
+    href="/agents/monitor/post-call-analysis"
+  >
+    Extract structured data from every call.
+  </Card>
+  <Card title="Webhooks" icon="webhook" href="/agents/monitor/webhooks">
+    React to call lifecycle events from your backend.
+  </Card>
+</CardGroup>

--- a/agents/telephony/phone-numbers.mdx
+++ b/agents/telephony/phone-numbers.mdx
@@ -1,0 +1,188 @@
+---
+title: "Phone Numbers"
+description: "Search, purchase, bind, and release phone numbers for your agents over the REST API"
+icon: "phone"
+---
+
+Phone numbers connect your agents to the telephone network. Each number lives in a workspace within your team (purchases land in your default workspace) and is bound to at most one agent — calls to the number are answered by that agent. The `/v1/agent/phone-numbers` API covers the whole lifecycle: search the purchasable inventory, buy a number, bind it to an agent, and release it when you no longer need it.
+
+## Search available numbers
+
+Search the purchasable inventory for a number to buy.
+
+```bash Request
+curl "https://api.fish.audio/v1/agent/available-phone-numbers?country_code=US&area_code=415" \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+The response is an `available_phone_numbers` array of inventory entries forwarded from the provider — number and region.
+
+| Parameter      | Description                                                                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `country_code` | ISO 3166-1 alpha-2 country code. Default `US`.                                                                                             |
+| `area_code`    | Restrict results to one area code, like `415`.                                                                                             |
+| `number_type`  | `local` (default). The managed inventory is US local numbers only; `toll_free` returns `400`.                                              |
+| `provider`     | Inventory to search. Only `twilio` (the default) is available — managed numbers with [call transfer](/agents/telephony/transfers) support. |
+
+<Note>
+  Availability is not a reservation — a listed number can still be claimed by
+  someone else before you buy it.
+</Note>
+
+## Purchase a number
+
+Buy a number from the inventory with the same `provider` that listed it.
+
+```bash Request
+curl --request POST https://api.fish.audio/v1/agent/phone-numbers \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "provider": "twilio",
+    "phone_number": "+14155550123",
+    "label": "Support line (US)",
+    "agent_id": "4f2a8c6e1b3d5f7a9c0e2d4b6a8f1c3e"
+  }'
+```
+
+Returns `201` with the number object — the same shape the list endpoint returns. The number lands in your default workspace, and its monthly price is billed in daily slices.
+
+| Field          | Description                                                              |
+| -------------- | ------------------------------------------------------------------------ |
+| `provider`     | Required — `twilio`, the inventory the number came from.                 |
+| `phone_number` | Required — an E.164 number from the search response.                     |
+| `label`        | Optional free-form label, up to 120 characters.                          |
+| `agent_id`     | Optional — bind an agent so the number answers inbound calls right away. |
+
+A `409` means the number is already on the platform; a `502` means the provider refused the purchase — the number stays visible with status `error` and is safe to release.
+
+## List your numbers
+
+Returns your team's phone numbers across its workspaces, newest first — each carries its `workspace_id`.
+
+<CodeGroup>
+```bash Request
+curl https://api.fish.audio/v1/agent/phone-numbers \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+```json Response
+{
+  "phone_numbers": [
+    {
+      "phone_number_id": "7c9e6f2a4b8d4e1f9a3c5d7e8f0b1a2c",
+      "phone_number": "+14155550123",
+      "provider": "twilio",
+      "label": "Support line (US)",
+      "agent_id": "4f2a8c6e1b3d5f7a9c0e2d4b6a8f1c3e",
+      "status": "active"
+    }
+  ],
+  "has_more": false
+}
+```
+
+</CodeGroup>
+
+| Field             | Description                                                      |
+| ----------------- | ---------------------------------------------------------------- |
+| `phone_number_id` | Unique identifier — use it in URL paths                          |
+| `phone_number`    | The number in E.164 format                                       |
+| `provider`        | Telephony provider backing the number                            |
+| `label`           | Free-form label you assign                                       |
+| `agent_id`        | The agent that answers calls to this number; `null` when unbound |
+| `status`          | `provisioning`, `active`, or `error`                             |
+
+## Get a single number
+
+```bash Request
+curl https://api.fish.audio/v1/agent/phone-numbers/$PHONE_NUMBER_ID \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+Returns the same number object as the list endpoint.
+
+## Bind or unbind an agent
+
+`PATCH` the number with an `agent_id` to change which agent answers it. Binding is resolved per call, so the change applies from the next inbound call — nothing to redeploy.
+
+<CodeGroup>
+```bash Bind
+curl --request PATCH https://api.fish.audio/v1/agent/phone-numbers/$PHONE_NUMBER_ID \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{ "agent_id": "4f2a8c6e1b3d5f7a9c0e2d4b6a8f1c3e" }'
+```
+
+```bash Unbind
+curl --request PATCH https://api.fish.audio/v1/agent/phone-numbers/$PHONE_NUMBER_ID \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{ "agent_id": null }'
+```
+
+</CodeGroup>
+
+Omitted fields are left unchanged — only an explicit `"agent_id": null` unbinds the number.
+
+<Tip>
+  Re-binding is how you promote an agent behind a stable number: point the
+  number at a staging agent while you iterate, then `PATCH` it over to the
+  production agent when you're ready. The number itself never changes.
+</Tip>
+
+## Label your numbers
+
+Labels are free-form text for keeping an inventory readable — by team, region, campaign, or environment.
+
+```bash Request
+curl --request PATCH https://api.fish.audio/v1/agent/phone-numbers/$PHONE_NUMBER_ID \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{ "label": "Support line (US)" }'
+```
+
+The response is the updated number object.
+
+## Release a number
+
+Release a number back to the provider's inventory. Returns `204`, daily billing stops, and the number disappears from the API immediately.
+
+```bash Request
+curl --request DELETE https://api.fish.audio/v1/agent/phone-numbers/$PHONE_NUMBER_ID \
+  --header "Authorization: Bearer $FISH_API_KEY"
+```
+
+<Warning>
+  Releasing is irreversible. Anyone — including other platforms — can buy the
+  number afterwards, so callers who saved it may reach a stranger.
+</Warning>
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card
+    title="Inbound calls"
+    icon="phone-arrow-down-left"
+    href="/agents/telephony/inbound-calls"
+  >
+    What happens when someone dials a bound number.
+  </Card>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    API keys and workspace scoping for every request.
+  </Card>
+  <Card
+    title="Conversation history"
+    icon="clock-rotate-left"
+    href="/agents/monitor/conversation-history"
+  >
+    Review phone sessions, transcripts, and recordings.
+  </Card>
+  <Card
+    title="Versions & publishing"
+    icon="rocket"
+    href="/agents/deploy/versions-publishing"
+  >
+    Publish configuration changes behind a stable number.
+  </Card>
+</CardGroup>

--- a/agents/telephony/transfers.mdx
+++ b/agents/telephony/transfers.mdx
@@ -1,0 +1,152 @@
+---
+title: "Call Transfers"
+description: "Let the agent hand a phone call to a human — a cold carrier handoff, or a warm transfer with hold music and a private briefing"
+icon: "phone-arrow-right"
+---
+
+When a caller needs a person, the agent can transfer the call. Configure a destination number and the agent gains a built-in `transfer_call` tool it invokes when the caller asks for a human or the request clearly needs one. Transfers apply to phone calls only.
+
+Two modes decide what the handoff feels like:
+
+|                                | Cold                                                                                                        | Warm                                                                                                                                                                  |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Handoff**                    | The agent announces the transfer and drops out; the carrier connects the caller to the destination.         | The caller waits on hold while the agent briefs the human on a private call, then the two are connected.                                                              |
+| **What the human hears first** | The caller, directly.                                                                                       | The agent's briefing: who is calling and what they need.                                                                                                              |
+| **Recording & analysis**       | Stop at the handoff — nothing after it appears in [post-call analysis](/agents/monitor/post-call-analysis). | Recording continues after the human joins, capturing the full call audio; the transcript — and therefore analysis — covers only the agent's segment, up to the merge. |
+
+## Prerequisites
+
+- A phone number bound to your agent, answering inbound calls — see [Inbound calls](/agents/telephony/inbound-calls).
+- The number must support transfers — numbers purchased from the platform inventory (`provider: "twilio"`) do; see [Phone numbers](/agents/telephony/phone-numbers).
+
+## Configure a destination
+
+### In the console
+
+On the agent's **Phone** page, under **Inbound calls**, turn on **Call transfer**. Give the destination a name, enter its phone number, and pick the transfer mode — choosing **Warm** adds a handoff choice (ask the human to accept first, or connect immediately after the briefing). Like every config edit, the change lands in the agent's draft and takes effect on live calls after you [publish](/agents/deploy/versions-publishing).
+
+### Through the API
+
+Transfer destinations live in the `conversation` section of the [agent config](/agents/build/configuration), as `transfer_destinations`. An empty list disables transfers; only one destination is supported for now — a longer list is rejected.
+
+<CodeGroup>
+```bash Enable
+curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "conversation": {
+      "transfer_destinations": [
+        {
+          "label": "Support desk",
+          "phone_number": "+14155550123",
+          "mode": "warm",
+          "warm_connect": "confirm"
+        }
+      ]
+    }
+  }'
+```
+
+```bash Disable
+curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{ "conversation": { "transfer_destinations": [] } }'
+```
+
+</CodeGroup>
+
+| Field          | Description                                                                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `type`         | Destination type; `phone` is the only value today and the default.                                                           |
+| `label`        | Name for the destination, shown in the Builder. At most 64 characters.                                                       |
+| `phone_number` | The destination in E.164 format, for example `+14155550123`.                                                                 |
+| `mode`         | `cold` (default) or `warm` — see the comparison above.                                                                       |
+| `warm_connect` | Warm only: `confirm` (default) waits for the human's go-ahead before connecting; `direct` connects right after the briefing. |
+
+Destination numbers must be E.164 and are limited to a set of supported countries — a number outside the list is rejected with `422 Unprocessable Entity` and an error naming the allowed country codes. The transfer card in the console shows the current list.
+
+## How the agent decides to transfer
+
+Configuring a destination is what enables the built-in `transfer_call` tool — there is no separate switch, and an empty destination list removes the tool. Unlike the toggled [system tools](/agents/build/system-tools), you won't find it in the `tools` config section; it ships automatically on phone sessions whenever a valid destination exists.
+
+The built-in instructions are conservative: the agent transfers only when the caller asks for a person, or when the request clearly needs one and the agent cannot help further — never preemptively for questions it can answer itself.
+
+<Tip>
+  Use the system prompt to sharpen the escalation policy — for example,
+  "Transfer to a human whenever the caller mentions a refund." See
+  [Tools](/agents/build/tools) for how the agent chooses between its tools.
+</Tip>
+
+## What happens on a cold transfer
+
+The agent tells the caller it is transferring them, and once that sentence finishes playing the call is handed to the carrier. The caller hears a dial tone while the destination rings; the agent drops out and its session ends at the handoff.
+
+If the handoff is refused — the destination is unreachable, or the number doesn't support transfers — the agent stays on the line, apologizes, and keeps helping. It can attempt the transfer again later.
+
+## What happens on a warm transfer
+
+<Steps>
+  <Step title="The caller goes on hold">
+    The agent asks the caller to hold for a moment — in the session's language —
+    and hold music starts.
+  </Step>
+  <Step title="The platform dials your human agent">
+    A separate, private consult call rings the destination for up to 30 seconds.
+    It presents the number the caller originally dialed as caller ID, so your
+    team sees a number they recognize.
+  </Step>
+  <Step title="The agent briefs the human">
+    The agent greets the human and relays short third-person notes on who is
+    calling and what they need, generated from the conversation so far. The
+    caller hears none of this.
+  </Step>
+  <Step title="The calls merge">
+    With `warm_connect: "confirm"` the merge waits for the human to agree; with
+    `direct` it happens right after the briefing. The hold music stops, the
+    human joins the caller, and the agent leaves without another word.
+  </Step>
+</Steps>
+
+If the human cannot be reached, declines, or the consult call hits voicemail, the caller comes off hold and the agent apologizes and continues helping — it can retry if the caller asks. If the caller hangs up while on hold, the agent briefly tells the human what happened and ends the consult call.
+
+## Limitations
+
+- **Phone calls only** — web and SDK sessions have no phone leg to hand off, so the `transfer_call` tool never ships for them.
+- **Transfer-capable numbers** — the number the caller dialed must be a `twilio`-provider number.
+- **One destination** — each agent supports a single transfer destination for now.
+- **Supported countries** — destination numbers are limited to an allowlist of country codes.
+
+## Billing
+
+Transferred call time is metered separately from agent time, with cold and warm transfers each billed at their own per-minute rate. The standard agent rate applies only while the agent itself is on the call — it stops at the handoff for cold transfers and at the merge for warm transfers, and the connected call is metered as transfer minutes from that point on.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card
+    title="Inbound calls"
+    icon="phone-arrow-down-left"
+    href="/agents/telephony/inbound-calls"
+  >
+    Bind a number and put your agent on the phone.
+  </Card>
+  <Card
+    title="Phone numbers"
+    icon="hashtag"
+    href="/agents/telephony/phone-numbers"
+  >
+    Number management, providers, and agent bindings.
+  </Card>
+  <Card title="System tools" icon="gears" href="/agents/build/system-tools">
+    The other built-in capabilities, like hanging up.
+  </Card>
+  <Card
+    title="Conversation history"
+    icon="clock-rotate-left"
+    href="/agents/monitor/conversation-history"
+  >
+    Review transcripts and recordings of transferred calls.
+  </Card>
+</CardGroup>

--- a/agents/test/agent-tests.mdx
+++ b/agents/test/agent-tests.mdx
@@ -1,0 +1,127 @@
+---
+title: "Agent Tests"
+description: "Script conversations and let an LLM judge score your agent's replies — catch regressions before you publish"
+icon: "vial"
+---
+
+Write a conversation once, run it against any agent, and get a **Pass** or **Fail** verdict with the judge's reasoning. Tests live in a shared workspace library, run against your agent's current draft, and never touch what's published — so you can iterate on a prompt and re-run in seconds.
+
+## How a test works
+
+A **Single Turn** test hands your agent a scripted conversation and asks it to produce the next reply:
+
+1. You script a conversation history of agent and user messages.
+2. The agent generates the next reply using its current **draft** configuration and the same language model that answers in live conversations.
+3. An LLM judge scores the reply against your **Expectation**, optionally calibrated by success and failure examples, and returns a verdict with its reasoning.
+
+<Note>
+  Tests run as text — no audio is synthesized — but the agent uses its full
+  draft configuration: the [knowledge base](/agents/build/knowledge-base) is
+  consulted, and the agent can invoke its attached tools while generating the
+  reply. [Webhook tools](/agents/build/webhook-tools) send real HTTP requests
+  during a test, so point them at a staging endpoint. For end-to-end
+  verification with voice, use [preview calls](/agents/test/preview-calls).
+</Note>
+
+## Create a test
+
+Tests are workspace-level resources, managed under **Library → Tests** in the console and shareable across every agent in your workspace.
+
+<Steps>
+  <Step title="Start a new test">
+    Open **Library → Tests** and click **New test**. Give it a name and keep the
+    type as **Single Turn**.
+  </Step>
+  <Step title="Script the conversation">
+    Under **Conversation**, click **Add message** to build the history the agent
+    sees — each message is either an **Agent** or **User** turn. When the test
+    runs, the agent generates the reply that comes next.
+  </Step>
+  <Step title="Define the judging criteria">
+    Under **Judging**, write the **Expectation** — what a correct reply must do.
+    Optionally click **Add example** to provide success and failure examples;
+    they calibrate the judge but aren't required.
+  </Step>
+  <Step title="Save">
+    Click **Save**. The test is now in your library, ready to attach to agents.
+  </Step>
+</Steps>
+
+<Note>
+  The type picker also offers **Tool** tests, available today, which check
+  whether the agent called a specific tool. **Multi Turn** tests are coming
+  soon.
+</Note>
+
+## Attach tests to agents
+
+A test only runs against agents it's attached to. Attach from either side:
+
+- **From the library** — open the test's **Access** tab and toggle it on for each agent.
+- **From the Builder** — on the agent's **Tests** page, click **Add tests** and pick from the library.
+
+One test can be attached to many agents, and each agent keeps its own last result. **Remove from agent** detaches the test from that agent only; **Delete** in the library removes the test from all agents.
+
+## Run a single test
+
+Open the test and switch to its **Run** tab. Pick an agent that has access, then click **Run test**. The verdict card shows:
+
+| Result          | What you see                                       |
+| --------------- | -------------------------------------------------- |
+| Verdict         | **Pass** (green) or **Fail** (red)                 |
+| Latency         | Time to generate and judge the reply, e.g. `1.8 s` |
+| Agent reply     | The full reply the agent generated                 |
+| Judge reasoning | Why the judge passed or failed the reply           |
+
+If the run can't complete, the verdict shows **Error** with the error message in place of the reply and reasoning.
+
+## Run every test for an agent
+
+On the agent's **Tests** page in the Builder, click **Run all**. Each row moves through **queued → running → Pass/Fail** — or **Error** if a run can't complete — and the page header summarizes the latest batch — for example, `4 passed, 1 failed on last run`. Use the row menu to re-run a single test, edit it, or remove it from the agent.
+
+## Tests run against the draft
+
+Tests always exercise the agent's latest **draft** configuration — including unpublished changes to the system prompt. That makes the loop fast:
+
+<Steps>
+  <Step title="Edit the draft">
+    Change the system prompt or first message in
+    [Configuration](/agents/build/configuration).
+  </Step>
+  <Step title="Re-run">Click **Run all** — no publish needed.</Step>
+  <Step title="Publish when green">
+    Once results look right, [publish the
+    draft](/agents/deploy/versions-publishing). Running tests never publishes
+    anything and doesn't affect your agent's publish state.
+  </Step>
+</Steps>
+
+## Limits
+
+| Field                     | Limit                                       |
+| ------------------------- | ------------------------------------------- |
+| Test name                 | 200 characters                              |
+| Conversation message      | 2,000 characters each, at least one message |
+| Expectation               | 400 characters                              |
+| Success / failure example | 400 characters each                         |
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Preview calls" icon="phone" href="/agents/test/preview-calls">
+    Talk to your draft agent live, with voice, tools, and transcripts.
+  </Card>
+  <Card
+    title="Versions & publishing"
+    icon="rocket"
+    href="/agents/deploy/versions-publishing"
+  >
+    How drafts become immutable published versions.
+  </Card>
+  <Card title="Configuration" icon="sliders" href="/agents/build/configuration">
+    System prompt, first message, and everything tests exercise.
+  </Card>
+  <Card title="Core concepts" icon="lightbulb" href="/agents/concepts">
+    Agents, drafts, sessions, and the workspace library model.
+  </Card>
+</CardGroup>

--- a/agents/test/preview-calls.mdx
+++ b/agents/test/preview-calls.mdx
@@ -1,0 +1,111 @@
+---
+title: "Preview Calls"
+description: "Talk to your draft agent in a live voice call, right in the Builder"
+icon: "headset"
+---
+
+Preview calls let you hold a live voice conversation with your agent without leaving the Builder. Every call runs against your current **draft** configuration — edit the system prompt, pick a different voice, and call again to hear the difference immediately, no publish required.
+
+## Start a preview call
+
+<Steps>
+  <Step title="Open your agent in the Builder">
+    Preview works from any Builder section — Configuration, Tools, Knowledge
+    base, and so on.
+  </Step>
+  <Step title="Click Test call">
+    The **Test call** button in the top bar opens the Preview panel on the right
+    side of the Builder.
+  </Step>
+  <Step title="Click Start call">
+    Your browser asks for microphone access the first time. The call cannot
+    start without a microphone — if you deny permission, the panel tells you to
+    allow access in your browser settings and try again.
+  </Step>
+  <Step title="Talk to your agent">
+    Once connected, the status pill shows **Live** with a running call timer.
+    The agent opens the call according to your [first message
+    settings](/agents/build/configuration), and the conversation begins.
+  </Step>
+</Steps>
+
+The panel stays connected while you switch between Builder sections, so you can read your configuration mid-call. Navigating away from the Builder — back to the agent list, for example — hangs up. If the call fails to connect, the panel shows an error state and lets you retry; a connection drop mid-call simply ends the call.
+
+## During the call
+
+### Live transcript
+
+The panel shows both sides of the conversation as it happens:
+
+- **Your speech** appears as it is transcribed, updating in place while you talk and settling when you finish a turn.
+- **Agent replies** stream in as text while the agent speaks them aloud.
+
+### Tool calls
+
+When the agent invokes a [tool](/agents/build/tools), the call appears inline in the transcript as a compact entry that flips from running to done or failed. Expand an entry to inspect the exact arguments the model sent and the response it received, as formatted JSON truncated at 4 KB.
+
+<Warning>
+  Preview calls run your real configuration. [Webhook
+  tools](/agents/build/webhook-tools) send real HTTP requests to your endpoints
+  — point them at a staging environment if you want to avoid side effects while
+  testing.
+</Warning>
+
+### Controls
+
+| Control  | Behavior                                                                                                                                       |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mute     | Toggles your microphone without ending the call                                                                                                |
+| End call | Ends the call and returns the panel to its ready state                                                                                         |
+| Timer    | Shows elapsed time; preview calls are capped at 10 minutes (600 seconds) — or the agent's configured maximum call duration, whichever is lower |
+
+## Drafts, not published versions
+
+Preview calls and production sessions read different configurations:
+
+| Session            | Configuration used                                       |
+| ------------------ | -------------------------------------------------------- |
+| Preview call       | Latest draft, autosaved as you edit in the Builder       |
+| Production session | The published version, unchanged until you publish again |
+
+This makes preview the fast inner loop: tweak the prompt, call, listen, repeat. Your published version — and every live integration using it — is untouched until you decide the draft is ready and [publish it](/agents/deploy/versions-publishing).
+
+<Tip>
+  After a config change, hang up and start a new call. A preview call reflects
+  the draft as it stood when the session was created.
+</Tip>
+
+## After the call
+
+Preview sessions are built for iteration, not record-keeping:
+
+- **Post-call analysis runs in the panel.** If you have [post-call analysis](/agents/monitor/post-call-analysis) configured, ending the call triggers it and the results — summary, extracted data fields, and per-criterion success / failure / unknown verdicts — appear directly in the panel. Analysis runs however the call ends — including the automatic time limit or closing the tab mid-call — but results are viewable only in the panel, so close the tab and you won't see them.
+- **Nothing enters conversation history.** Preview calls never appear in [conversation history](/agents/monitor/conversation-history), and the transcript is not preserved after you hang up.
+- **No post-call webhook fires.** Preview sessions never trigger the `call.analyzed` [post-call webhook](/agents/monitor/webhooks), so Builder debugging doesn't push analysis results to your production systems.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Agent tests" icon="vial" href="/agents/test/agent-tests">
+    Scripted conversations with automated Pass/Fail judging — catch regressions
+    without listening by ear.
+  </Card>
+  <Card
+    title="Versions & publishing"
+    icon="rocket"
+    href="/agents/deploy/versions-publishing"
+  >
+    Ship the draft you just previewed as an immutable published version.
+  </Card>
+  <Card
+    title="Post-call analysis"
+    icon="chart-simple"
+    href="/agents/monitor/post-call-analysis"
+  >
+    Configure summaries, data extraction, and success criteria — results show up
+    in the preview panel.
+  </Card>
+  <Card title="Web SDK" icon="code" href="/agents/deploy/web-sdk">
+    Put the same voice conversation in your own app.
+  </Card>
+</CardGroup>

--- a/api-reference/agent-errors.mdx
+++ b/api-reference/agent-errors.mdx
@@ -1,0 +1,101 @@
+---
+title: "Agents API Errors"
+description: "Status codes, error shapes, and recovery guidance for every /v1/agent endpoint"
+icon: "triangle-exclamation"
+---
+
+Errors from `/v1/agent/*` come back as JSON with a `status` and a `message`:
+
+```json
+{ "status": 404, "message": "Agent not found" }
+```
+
+The exceptions to that shape:
+
+- **Validation failures** (`422`) return pydantic's error list, one entry per problem. Offending input values are stripped, so write-only credentials are never echoed back:
+
+  ```json
+  [
+    {
+      "type": "string_too_long",
+      "loc": ["body", "prompt", "system_prompt"],
+      "msg": "String should have at most 4000 characters",
+      "ctx": { "max_length": 4000 }
+    }
+  ]
+  ```
+
+- A request body that isn't valid JSON returns `400` with `"Malformed JSON"`; a missing body or wrong `Content-Type` returns a bare `415`.
+- A missing or malformed `Authorization` header returns a bare `401` with a `WWW-Authenticate: Bearer` header; a present-but-bad credential returns the JSON shape (`"Invalid token"`, `"Token expired"`).
+
+## Status codes
+
+| Status | Meaning                                                                  | What to do                                                                                                       |
+| ------ | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `400`  | The request is well-formed JSON but semantically wrong                   | Read the `message` — it names the field or rule.                                                                 |
+| `401`  | Missing, invalid, or expired API key                                     | Send `Authorization: Bearer <key>`; check it on [API Keys](https://fish.audio/app/api-keys).                     |
+| `402`  | Out of API credit                                                        | Top up. Only session creation and phone-number purchase charge up front — a `402` never leaves a partial charge. |
+| `403`  | The action is not allowed for this caller                                | See [403 causes](#403-what-was-refused) below.                                                                   |
+| `404`  | The resource doesn't exist — or isn't yours                              | Cross-team access returns the same `404` as a missing id, so treat both identically.                             |
+| `409`  | A state conflict blocks the action                                       | See [409 conflicts](#409-conflicts) below.                                                                       |
+| `415`  | Missing body or wrong `Content-Type`                                     | JSON endpoints need `application/json`; knowledge-source uploads need `multipart/form-data`.                     |
+| `422`  | Field-level validation failed                                            | Fix the fields listed in the error array.                                                                        |
+| `429`  | Public session creation is rate limited                                  | Back off and retry; per-agent and per-IP windows apply to [public agents](/agents/deploy/public-agents) only.    |
+| `502`  | An upstream dependency (conversation gateway, telephony provider) failed | Retry; for a failed phone-number purchase the row stays visible with status `error` and is safe to release.      |
+| `503`  | A platform dependency is temporarily unavailable                         | Retry with backoff.                                                                                              |
+
+## 400 vs 422
+
+`422` is field-level validation: unknown fields (the public surface rejects them), length caps, enum values, invalid IANA timezones, dynamic-variable naming. `400` is semantic: an override not on the agent's allow-list, mutually exclusive pagination parameters (`page` + `cursor`), an undecodable cursor, a page offset past 100,000 rows, or a knowledge upload that isn't UTF-8 plain text.
+
+Two quirks worth coding around:
+
+- **Explicit `null` is rejected** on `PATCH` endpoints with `422` — omit a field to keep its value, send `""` to clear a text field.
+- **Path-parameter validation renders `404`, not `422`** — a non-integer `{version_number}` looks like a missing version.
+
+## 403: what was refused
+
+| Message                                          | Cause                                                                                                       |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| `Agent is not public`                            | Anonymous session/widget request against an agent whose public switch is off.                               |
+| `Origin header is required for public agents`    | Anonymous request without an `Origin` header — browsers send it automatically, curl must set it.            |
+| `Origin not allowed`                             | The page's origin is not on the agent's [allowed origins](/agents/deploy/public-agents#origin-matching).    |
+| `Agent is unavailable`                           | The agent's owner can't serve public sessions right now; visitors deliberately can't tell why.              |
+| `Agent platform is not enabled for this account` | Creating agent resources requires Agents access on your account — contact support if you expect to have it. |
+| `Phone number limit reached for this team (N)`   | The team holds its maximum of live numbers; release one first.                                              |
+
+## 404: anti-enumeration
+
+A resource that exists but belongs to another team returns the **identical** `404` body as one that never existed — for agents, sessions, tools, knowledge sources, phone numbers, and versions. Released phone numbers and deleted knowledge sources behave the same. Never use `404` vs `403` to probe for existence; there is no distinction to find.
+
+The recording endpoint adds one more meaning: `Recording not found` on a real session means it was [never recorded](/agents/monitor/conversation-history#what-gets-stored).
+
+## 409: conflicts
+
+| Message                                       | Cause and fix                                                                                                                                      |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Agent has no published version`              | Session creation against a never-published agent — [publish](/agents/deploy/versions-publishing) first.                                            |
+| `Knowledge source is attached to N agent(s)…` | Deletion is blocked while any agent references the source in its draft **or published** config — detach everywhere, republish, then delete.        |
+| `Tool is attached to N agent(s)…`             | Deletion is blocked while any agent's **draft** references the tool (published snapshots are frozen copies and don't block) — detach, then delete. |
+| `This number is already on the platform`      | The number is held by a team already — pick another from [search](/api-reference/endpoint/agent/search-available-phone-numbers).                   |
+
+## Billing and rate limits
+
+Exactly two endpoints charge before acting, and both can return `402 Out of API credit`: [`POST /v1/agent/sessions`](/api-reference/endpoint/agent/create-agent-session) (API-key callers) and [`POST /v1/agent/phone-numbers`](/api-reference/endpoint/agent/purchase-phone-number) (the first rental day). Anonymous public sessions never see `402` — an out-of-credit owner surfaces to visitors as `403 Agent is unavailable`. Usage is settled after each call and never fails a request.
+
+`429` applies only to anonymous session creation on [public agents](/agents/deploy/public-agents), in fixed per-minute windows per agent and per client IP. API-key traffic is not rate limited on this surface — your backend is the gate.
+
+## 5xx
+
+`502` names the failing upstream in the message: the conversation gateway (`Agent gateway is unreachable`) or the telephony provider (`Twilio refused the request: …`). Retrying is safe — a failed phone-number purchase leaves the row visible with status `error`, refunds the day charge, and can be released; a failed release keeps the number live so releasing again retries. `503` means a platform dependency was briefly unreachable; retry with backoff.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+    Both auth modes and the session token flow.
+  </Card>
+  <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
+    Origin allowlists and the errors unique to keyless access.
+  </Card>
+</CardGroup>

--- a/api-reference/endpoint/agent/create-agent-session.mdx
+++ b/api-reference/endpoint/agent/create-agent-session.mdx
@@ -1,0 +1,7 @@
+---
+openapi: post /v1/agent/sessions
+title: "Create Agent Session"
+description: "Start a conversation session with an agent and receive a join token for the\nsession transport (currently LiveKit WebRTC)."
+icon: "headset"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/create-agent.mdx
+++ b/api-reference/endpoint/agent/create-agent.mdx
@@ -1,0 +1,7 @@
+---
+openapi: post /v1/agent/agents
+title: "Create Agent"
+description: "Create an agent, optionally with its full initial configuration inline \u2014\none call provisions a ready-to-publish agent."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/create-knowledge-source.mdx
+++ b/api-reference/endpoint/agent/create-knowledge-source.mdx
@@ -1,0 +1,7 @@
+---
+openapi: post /v1/agent/knowledge-sources
+title: "Create Knowledge Source"
+description: "Upload a plain-text or Markdown file (UTF-8, up to 1 MB) as a knowledge\nsource."
+icon: "book"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/create-tool.mdx
+++ b/api-reference/endpoint/agent/create-tool.mdx
@@ -1,0 +1,7 @@
+---
+openapi: post /v1/agent/tools
+title: "Create Tool"
+description: "Create a workspace tool."
+icon: "wrench"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/delete-agent.mdx
+++ b/api-reference/endpoint/agent/delete-agent.mdx
@@ -1,0 +1,7 @@
+---
+openapi: delete /v1/agent/agents/{agent_id}
+title: "Delete Agent"
+description: "Delete an agent together with its configuration and version history.\nExisting session records are retained."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/delete-knowledge-source.mdx
+++ b/api-reference/endpoint/agent/delete-knowledge-source.mdx
@@ -1,0 +1,7 @@
+---
+openapi: delete /v1/agent/knowledge-sources/{source_id}
+title: "Delete Knowledge Source"
+description: "Delete a knowledge source."
+icon: "book"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/delete-tool.mdx
+++ b/api-reference/endpoint/agent/delete-tool.mdx
@@ -1,0 +1,7 @@
+---
+openapi: delete /v1/agent/tools/{tool_id}
+title: "Delete Tool"
+description: "Delete a tool."
+icon: "wrench"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/end-agent-session.mdx
+++ b/api-reference/endpoint/agent/end-agent-session.mdx
@@ -1,0 +1,7 @@
+---
+openapi: post /v1/agent/sessions/{session_id}/end
+title: "End Agent Session"
+description: "Hang up a live session: the agent disconnects and the call terminates."
+icon: "headset"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/get-agent-session-recording.mdx
+++ b/api-reference/endpoint/agent/get-agent-session-recording.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/sessions/{session_id}/recording
+title: "Get Agent Session Recording"
+description: "Return time-limited download URLs for the session's audio recording, one\nper speaker track (agent and user are recorded separately)."
+icon: "headset"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/get-agent-session.mdx
+++ b/api-reference/endpoint/agent/get-agent-session.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/sessions/{session_id}
+title: "Get Agent Session"
+description: "Fetch one session's full detail: status, timing, and the conversation\ntimeline (transcript turns interleaved with tool calls, in order)."
+icon: "headset"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/get-agent-version.mdx
+++ b/api-reference/endpoint/agent/get-agent-version.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/agents/{agent_id}/versions/{version_number}
+title: "Get Agent Version"
+description: "One published version with its full frozen configuration snapshot \u2014\nincluding the current live version."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/get-agent.mdx
+++ b/api-reference/endpoint/agent/get-agent.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/agents/{agent_id}
+title: "Get Agent"
+description: "Fetch one agent's profile fields."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/get-draft-config.mdx
+++ b/api-reference/endpoint/agent/get-draft-config.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/agents/{agent_id}/config
+title: "Get Draft Config"
+description: "Read the agent's current draft configuration \u2014 the state the next publish\nwill freeze."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/get-knowledge-source.mdx
+++ b/api-reference/endpoint/agent/get-knowledge-source.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/knowledge-sources/{source_id}
+title: "Get Knowledge Source"
+description: "Fetch one knowledge source including its full text content and current\nrevision number."
+icon: "book"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/get-phone-number.mdx
+++ b/api-reference/endpoint/agent/get-phone-number.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/phone-numbers/{phone_number_id}
+title: "Get Phone Number"
+description: "Fetch one phone number, including its current agent binding and\nprovisioning status."
+icon: "phone"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/get-tool.mdx
+++ b/api-reference/endpoint/agent/get-tool.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/tools/{tool_id}
+title: "Get Tool"
+description: "Fetch one tool's full definition."
+icon: "wrench"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/get-widget-config.mdx
+++ b/api-reference/endpoint/agent/get-widget-config.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/agents/{agent_id}/widget
+title: "Get Widget Config"
+description: "Unauthenticated display configuration for the embeddable `<fish-agent>`\nwidget."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/list-agent-sessions.mdx
+++ b/api-reference/endpoint/agent/list-agent-sessions.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/sessions
+title: "List Agent Sessions"
+description: "List your team's sessions, newest first."
+icon: "headset"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/list-agent-versions.mdx
+++ b/api-reference/endpoint/agent/list-agent-versions.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/agents/{agent_id}/versions
+title: "List Agent Versions"
+description: "The publish history, newest first."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/list-agents-using-knowledge-source.mdx
+++ b/api-reference/endpoint/agent/list-agents-using-knowledge-source.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/knowledge-sources/{source_id}/agents
+title: "List Agents Using Knowledge Source"
+description: "Every agent that references this source in its draft or currently\npublished configuration \u2014 the pre-flight check before a delete."
+icon: "book"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/list-agents-using-tool.mdx
+++ b/api-reference/endpoint/agent/list-agents-using-tool.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/tools/{tool_id}/agents
+title: "List Agents Using Tool"
+description: "Every agent whose draft configuration references this tool \u2014 the\npre-flight check before a delete."
+icon: "wrench"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/list-agents.mdx
+++ b/api-reference/endpoint/agent/list-agents.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/agents
+title: "List Agents"
+description: "List your team's agents, newest first."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/list-knowledge-sources.mdx
+++ b/api-reference/endpoint/agent/list-knowledge-sources.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/knowledge-sources
+title: "List Knowledge Sources"
+description: "List your team's knowledge sources, newest first."
+icon: "book"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/list-phone-numbers.mdx
+++ b/api-reference/endpoint/agent/list-phone-numbers.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/phone-numbers
+title: "List Phone Numbers"
+description: "List your team's phone numbers, newest first."
+icon: "phone"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/list-tools.mdx
+++ b/api-reference/endpoint/agent/list-tools.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/tools
+title: "List Tools"
+description: "List your team's tools, newest first."
+icon: "wrench"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/publish-agent.mdx
+++ b/api-reference/endpoint/agent/publish-agent.mdx
@@ -1,0 +1,7 @@
+---
+openapi: post /v1/agent/agents/{agent_id}/publish
+title: "Publish Agent"
+description: "Freeze the current draft into an immutable version (version_number\nauto-increments) and make it the live configuration for new sessions."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/purchase-phone-number.mdx
+++ b/api-reference/endpoint/agent/purchase-phone-number.mdx
@@ -1,0 +1,7 @@
+---
+openapi: post /v1/agent/phone-numbers
+title: "Purchase Phone Number"
+description: "Buy a number from the inventory."
+icon: "phone"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/release-phone-number.mdx
+++ b/api-reference/endpoint/agent/release-phone-number.mdx
@@ -1,0 +1,7 @@
+---
+openapi: delete /v1/agent/phone-numbers/{phone_number_id}
+title: "Release Phone Number"
+description: "Release a number back to the provider's inventory and stop its daily\nbilling."
+icon: "phone"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/search-available-phone-numbers.mdx
+++ b/api-reference/endpoint/agent/search-available-phone-numbers.mdx
@@ -1,0 +1,7 @@
+---
+openapi: get /v1/agent/available-phone-numbers
+title: "Search Available Phone Numbers"
+description: "Search the purchasable number inventory."
+icon: "phone"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/update-agent.mdx
+++ b/api-reference/endpoint/agent/update-agent.mdx
@@ -1,0 +1,7 @@
+---
+openapi: patch /v1/agent/agents/{agent_id}
+title: "Update Agent"
+description: "Update agent-level fields (name, description, status, public access and\nsession-override policy)."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/update-draft-config.mdx
+++ b/api-reference/endpoint/agent/update-draft-config.mdx
@@ -1,0 +1,7 @@
+---
+openapi: patch /v1/agent/agents/{agent_id}/config
+title: "Update Draft Config"
+description: "Patch the draft configuration section by section; omitted sections keep\ntheir value."
+icon: "robot"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/update-knowledge-source.mdx
+++ b/api-reference/endpoint/agent/update-knowledge-source.mdx
@@ -1,0 +1,7 @@
+---
+openapi: patch /v1/agent/knowledge-sources/{source_id}
+title: "Update Knowledge Source"
+description: "Rename the source and/or replace its content by uploading a new file in\n`source` (multipart)."
+icon: "book"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/update-phone-number.mdx
+++ b/api-reference/endpoint/agent/update-phone-number.mdx
@@ -1,0 +1,7 @@
+---
+openapi: patch /v1/agent/phone-numbers/{phone_number_id}
+title: "Update Phone Number"
+description: "Change the label and/or repoint the number at another agent \u2014 the\ndeployment-pipeline move (rebind from the staging agent to the production\none)."
+icon: "phone"
+iconType: "solid"
+---

--- a/api-reference/endpoint/agent/update-tool.mdx
+++ b/api-reference/endpoint/agent/update-tool.mdx
@@ -1,0 +1,7 @@
+---
+openapi: patch /v1/agent/tools/{tool_id}
+title: "Update Tool"
+description: "Patch tool fields; omitted fields keep their value (null is rejected \u2014\nsend an empty string to clear a text field)."
+icon: "wrench"
+iconType: "solid"
+---

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -2912,7 +2912,7 @@
           {
             "lang": "bash",
             "label": "Update Draft Config",
-            "source": "curl --request PATCH \\\n  --url https://api.fish.audio/v1/agent/agents/<agent-id>/config \\\n  --header 'Authorization: Bearer <token>' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"prompt\": {\n      \"system_prompt\": \"You are the receptionist for Fish Dental.\"\n    },\n    \"webhooks\": {\n      \"post_call\": {\n        \"url\": \"https://example.com/hooks/fish\",\n        \"secret\": \"<signing-secret>\"\n      }\n    }\n  }'"
+            "source": "curl --request PATCH \\\n  --url https://api.fish.audio/v1/agent/agents/<agent-id>/config \\\n  --header 'Authorization: Bearer <token>' \\\n  --header 'Content-Type: application/json' \\\n  --data '{\n    \"prompt\": {\n      \"system_prompt\": \"You are the receptionist for Fish Dental.\"\n    },\n    \"webhooks\": {\n      \"post_call\": [\n        {\n          \"url\": \"https://example.com/hooks/fish\",\n          \"secret\": \"<signing-secret>\"\n        }\n      ]\n    }\n  }'"
           }
         ]
       }
@@ -6895,11 +6895,11 @@
         "requestBody": {
           "required": true,
           "content": {
-            "application/json": {
+            "multipart/form-data": {
               "schema": {
                 "properties": {
                   "audio": {
-                    "description": "Audio to be converted to text",
+                    "description": "Audio file to be converted to text",
                     "format": "binary",
                     "title": "Audio",
                     "type": "string"
@@ -6914,7 +6914,7 @@
                       }
                     ],
                     "default": null,
-                    "description": "Language to be used for the speech",
+                    "description": "Optional hint. The language is auto-detected regardless; the detected language is returned as `language_code`.",
                     "title": "Language"
                   },
                   "ignore_timestamps": {
@@ -6934,7 +6934,7 @@
               "schema": {
                 "properties": {
                   "audio": {
-                    "description": "Audio to be converted to text",
+                    "description": "Audio file to be converted to text",
                     "format": "binary",
                     "title": "Audio",
                     "type": "string"
@@ -6949,7 +6949,7 @@
                       }
                     ],
                     "default": null,
-                    "description": "Language to be used for the speech",
+                    "description": "Optional hint. The language is auto-detected regardless; the detected language is returned as `language_code`.",
                     "title": "Language"
                   },
                   "ignore_timestamps": {
@@ -6990,6 +6990,32 @@
                       },
                       "title": "Segments",
                       "type": "array"
+                    },
+                    "language_code": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Detected language as an ISO 639-1 code (e.g. `en`, `ja`). Omitted if no language is detected.",
+                      "title": "Language Code"
+                    },
+                    "language": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "Detected language name (e.g. `English`). For display only; use `language_code` in code.",
+                      "title": "Language"
                     }
                   },
                   "required": [
@@ -7175,7 +7201,7 @@
           },
           {
             "lang": "bash",
-            "label": "Multi Speaker (S2.1 Pro only)",
+            "label": "Multi Speaker (S2 family only)",
             "source": "curl --request POST \\\n  --url https://api.fish.audio/v1/tts \\\n  --header 'Authorization: Bearer <token>' \\\n  --header 'Content-Type: application/json' \\\n  --header 'model: s2.1-pro-free' \\\n  --data '{\n    \"text\": \"<|speaker:0|>Hello!<|speaker:1|>Hi there!\",\n    \"reference_id\": [\"speaker-a-id\", \"speaker-b-id\"],\n    \"temperature\": 0.7,\n    \"top_p\": 0.7,\n    \"prosody\": {\n      \"speed\": 1,\n      \"volume\": 0,\n      \"normalize_loudness\": true\n    },\n    \"chunk_length\": 300,\n    \"normalize\": true,\n    \"format\": \"mp3\",\n    \"sample_rate\": 44100,\n    \"mp3_bitrate\": 128,\n    \"latency\": \"normal\",\n    \"max_new_tokens\": 1024,\n    \"repetition_penalty\": 1.2,\n    \"min_chunk_length\": 50,\n    \"condition_on_previous_chunks\": true,\n    \"early_stop_threshold\": 1\n  }'"
           }
         ]
@@ -11635,13 +11661,19 @@
           "post_call": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PublicPostCallWebhookPayload"
+                "items": {
+                  "$ref": "#/components/schemas/PublicPostCallWebhookPayload"
+                },
+                "maxItems": 5,
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "default": null
+            "default": null,
+            "description": "Up to 5 endpoints, each receiving every post-call event. Replaces the configured list wholesale; a single object is still accepted and is stored as a one-element list, and null (or an empty list) clears every endpoint. URLs must be unique.",
+            "title": "Post Call"
           }
         },
         "title": "PublicAgentWebhooksPatch",
@@ -12024,7 +12056,7 @@
             "type": "string"
           },
           "first_message_prompt": {
-            "default": "Greet the caller warmly, mention you can help with orders and callbacks.",
+            "default": "Greet the caller and ask what you can help with.",
             "title": "First Message Prompt",
             "type": "string"
           }
@@ -12157,15 +12189,11 @@
       "PublicAgentWebhooksConfig": {
         "properties": {
           "post_call": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/PublicPostCallWebhook"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null
+            "items": {
+              "$ref": "#/components/schemas/PublicPostCallWebhook"
+            },
+            "title": "Post Call",
+            "type": "array"
           }
         },
         "title": "PublicAgentWebhooksConfig",
@@ -13045,7 +13073,7 @@
           },
           "normalize_loudness": {
             "default": true,
-            "description": "Normalize output loudness for more consistent perceived volume. **S2-Pro only.**",
+            "description": "Normalize output loudness for more consistent perceived volume. Applies to the S2 family (`s2-pro`, `s2.1-pro`, `s2.1-pro-free`); on `s1` it is accepted but has no effect.",
             "title": "Normalize Loudness",
             "type": "boolean"
           }
@@ -13076,7 +13104,7 @@
         "type": "object"
       },
       "TTSRequest": {
-        "description": "Request body for text-to-speech synthesis. Supports single-speaker synthesis on all compatible TTS models. Multi-speaker dialogue synthesis is only available with the S2-Pro model.\n\n## Single Speaker\nProvide either `reference_id` (string) pointing to a voice model, or `references` (array of ReferenceAudio) for zero-shot cloning.\n\n## Multiple Speakers (Dialogue, S2-Pro only)\nFor multi-speaker synthesis, provide:\n- `reference_id`: array of voice model IDs, e.g., [\"speaker-0-id\", \"speaker-1-id\"]\n- `text`: use speaker tags `<|speaker:0|>`, `<|speaker:1|>`, etc. to indicate speaker changes, e.g., \"<|speaker:0|>Hello!<|speaker:1|>Hi there!\"\n\nAlternatively, for zero-shot multi-speaker:\n- `references`: 2D array where each inner array contains references for one speaker\n- `reference_id`: array of identifiers (can be arbitrary strings for zero-shot)\n\n## Example (Multi-Speaker with Model IDs)\n```json\n{\n  \"text\": \"<|speaker:0|>Good morning!<|speaker:1|>Good morning! How are you?<|speaker:0|>I'm great, thanks!\",\n  \"reference_id\": [\"model-id-alice\", \"model-id-bob\"]\n}\n```",
+        "description": "Request body for text-to-speech synthesis. Supports single-speaker synthesis on all compatible TTS models. Multi-speaker dialogue synthesis is only available with the S2 family (`s2-pro`, `s2.1-pro`, `s2.1-pro-free`), not `s1`.\n\n## Single Speaker\nProvide either `reference_id` (string) pointing to a voice model, or `references` (array of ReferenceAudio) for zero-shot cloning.\n\n## Multiple Speakers (Dialogue — S2 family only)\nFor multi-speaker synthesis, provide:\n- `reference_id`: array of voice model IDs, e.g., [\"speaker-0-id\", \"speaker-1-id\"]\n- `text`: use speaker tags `<|speaker:0|>`, `<|speaker:1|>`, etc. to indicate speaker changes, e.g., \"<|speaker:0|>Hello!<|speaker:1|>Hi there!\"\n\nAlternatively, for zero-shot multi-speaker:\n- `references`: 2D array where each inner array contains references for one speaker\n- `reference_id`: array of identifiers (can be arbitrary strings for zero-shot)\n\n## Example (Multi-Speaker with Model IDs)\n```json\n{\n  \"text\": \"<|speaker:0|>Good morning!<|speaker:1|>Good morning! How are you?<|speaker:0|>I'm great, thanks!\",\n  \"reference_id\": [\"model-id-alice\", \"model-id-bob\"]\n}\n```",
         "properties": {
           "text": {
             "description": "Text to convert to speech.",
@@ -13122,7 +13150,7 @@
                 "type": "null"
               }
             ],
-            "description": "Inline voice references for zero-shot cloning. Requires MessagePack (not JSON). For single speaker, provide an array of ReferenceAudio objects. For multiple speakers, provide an array of arrays where each inner array contains references for one speaker. **Multi-speaker is only available with the S2-Pro model.** The speaker index corresponds to the index in reference_id array. Example for multi-speaker: [[{audio, text}], [{audio, text}, {audio, text}]] for 2 speakers where speaker 1 has 2 reference samples.",
+            "description": "Inline voice references for zero-shot cloning. Requires MessagePack (not JSON). For single speaker, provide an array of ReferenceAudio objects. For multiple speakers, provide an array of arrays where each inner array contains references for one speaker. **Multi-speaker is only available with the S2 family (`s2-pro`, `s2.1-pro`, `s2.1-pro-free`), not `s1`.** The speaker index corresponds to the index in reference_id array. Example for multi-speaker: [[{audio, text}], [{audio, text}, {audio, text}]] for 2 speakers where speaker 1 has 2 reference samples.",
             "title": "References"
           },
           "reference_id": {
@@ -13143,7 +13171,7 @@
               }
             ],
             "default": null,
-            "description": "Voice model ID(s) from Fish Audio library or your custom models. For single-speaker synthesis, provide a string. For multi-speaker synthesis (dialogue), provide an array of model IDs. **Multi-speaker is only available with the S2-Pro model.** When using multiple speakers, use speaker tags in your text like `<|speaker:0|>` and `<|speaker:1|>` to indicate speaker changes. Example: `<|speaker:0|>Hello!<|speaker:1|>Hi there!<|speaker:0|>How are you?` with `reference_id: [\"speaker-a-id\", \"speaker-b-id\"]`.",
+            "description": "Voice model ID(s) from Fish Audio library or your custom models. For single-speaker synthesis, provide a string. For multi-speaker synthesis (dialogue), provide an array of model IDs. **Multi-speaker is only available with the S2 family (`s2-pro`, `s2.1-pro`, `s2.1-pro-free`), not `s1`.** When using multiple speakers, use speaker tags in your text like `<|speaker:0|>` and `<|speaker:1|>` to indicate speaker changes. Example: `<|speaker:0|>Hello!<|speaker:1|>Hi there!<|speaker:0|>How are you?` with `reference_id: [\"speaker-a-id\", \"speaker-b-id\"]`.",
             "title": "Reference Id"
           },
           "prosody": {
@@ -13329,7 +13357,7 @@
                 "type": "null"
               }
             ],
-            "description": "Inline voice references for zero-shot cloning. Requires MessagePack (not JSON). For single speaker, provide an array of ReferenceAudio objects. For multiple speakers, provide an array of arrays where each inner array contains references for one speaker. **Multi-speaker is only available with the S2-Pro model.** The speaker index corresponds to the index in reference_id array. Example for multi-speaker: [[{audio, text}], [{audio, text}, {audio, text}]] for 2 speakers where speaker 1 has 2 reference samples.",
+            "description": "Inline voice references for zero-shot cloning. Requires MessagePack (not JSON). For single speaker, provide an array of ReferenceAudio objects. For multiple speakers, provide an array of arrays where each inner array contains references for one speaker. **Multi-speaker is only available with the S2 family (`s2-pro`, `s2.1-pro`, `s2.1-pro-free`), not `s1`.** The speaker index corresponds to the index in reference_id array. Example for multi-speaker: [[{audio, text}], [{audio, text}, {audio, text}]] for 2 speakers where speaker 1 has 2 reference samples.",
             "title": "References"
           },
           "reference_id": {
@@ -13350,7 +13378,7 @@
               }
             ],
             "default": null,
-            "description": "Voice model ID(s) from Fish Audio library or your custom models. For single-speaker synthesis, provide a string. For multi-speaker synthesis (dialogue), provide an array of model IDs. **Multi-speaker is only available with the S2-Pro model.** When using multiple speakers, use speaker tags in your text like `<|speaker:0|>` and `<|speaker:1|>` to indicate speaker changes. Example: `<|speaker:0|>Hello!<|speaker:1|>Hi there!<|speaker:0|>How are you?` with `reference_id: [\"speaker-a-id\", \"speaker-b-id\"]`.",
+            "description": "Voice model ID(s) from Fish Audio library or your custom models. For single-speaker synthesis, provide a string. For multi-speaker synthesis (dialogue), provide an array of model IDs. **Multi-speaker is only available with the S2 family (`s2-pro`, `s2.1-pro`, `s2.1-pro-free`), not `s1`.** When using multiple speakers, use speaker tags in your text like `<|speaker:0|>` and `<|speaker:1|>` to indicate speaker changes. Example: `<|speaker:0|>Hello!<|speaker:1|>Hi there!<|speaker:0|>How are you?` with `reference_id: [\"speaker-a-id\", \"speaker-b-id\"]`.",
             "title": "Reference Id"
           },
           "prosody": {

--- a/developer-guide/resources/agent-quickstart.mdx
+++ b/developer-guide/resources/agent-quickstart.mdx
@@ -1,7 +1,8 @@
 ---
-title: "Agent Quickstart"
-description: "Build with Fish Audio using your AI coding agent — install the skill and start prompting in a minute"
-icon: "robot"
+title: "Coding Assistant Quickstart"
+sidebarTitle: "Coding Assistants"
+description: "Build with Fish Audio using your AI coding assistant — install the skill and start prompting in a minute"
+icon: "laptop-code"
 ---
 
 Install the Fish Audio **agent skill** and your coding agent — Claude Code, Cursor, Codex, and others — writes correct, current Fish Audio code: right method names, units, and error types, instead of guessing. Here's the fastest path.
@@ -22,6 +23,7 @@ Install the Fish Audio **agent skill** and your coding agent — Claude Code, Cu
         Raw REST + WebSocket for any language — auth, endpoints, MessagePack/JSON/multipart rules, and the streaming protocol.
       </Card>
     </CardGroup>
+
   </Step>
 
   <Step title="Set your API key">
@@ -30,6 +32,7 @@ Install the Fish Audio **agent skill** and your coding agent — Claude Code, Cu
     ```bash
     export FISH_API_KEY="your_api_key_here"
     ```
+
   </Step>
 
   <Step title="Ask your agent">
@@ -49,6 +52,7 @@ Install the Fish Audio **agent skill** and your coding agent — Claude Code, Cu
         "Call the Fish Audio TTS REST API from Go, no SDK."
       </Card>
     </CardGroup>
+
   </Step>
 </Steps>
 
@@ -71,25 +75,48 @@ npx skills add https://docs.fish.audio -a claude-code
 ```bash List / inspect first
 npx skills add https://docs.fish.audio --list
 ```
+
 </CodeGroup>
 
-<Card title="AI Coding Agents — full guide" icon="robot" href="/developer-guide/resources/coding-agents" horizontal>
-  Targeting specific agents, the Fish Audio MCP server, and reading the skills before you install.
+<Card
+  title="AI Coding Assistants — full guide"
+  icon="laptop-code"
+  href="/developer-guide/resources/coding-agents"
+  horizontal
+>
+  Targeting specific agents, the Fish Audio MCP server, and reading the skills
+  before you install.
 </Card>
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Get your API key" icon="key" href="/developer-guide/getting-started/api-key">
+  <Card
+    title="Get your API key"
+    icon="key"
+    href="/developer-guide/getting-started/api-key"
+  >
     Create a key and make your first request.
   </Card>
-  <Card title="Quick Start" icon="rocket" href="/developer-guide/getting-started/quickstart">
+  <Card
+    title="Quick Start"
+    icon="rocket"
+    href="/developer-guide/getting-started/quickstart"
+  >
     Generate your first audio by hand, in any language.
   </Card>
-  <Card title="Text to Speech" icon="microphone" href="/features/text-to-speech">
+  <Card
+    title="Text to Speech"
+    icon="microphone"
+    href="/features/text-to-speech"
+  >
     Voices, formats, streaming, and the direct API.
   </Card>
-  <Card title="API reference" icon="book-open" href="/api-reference/introduction">
+  <Card
+    title="API reference"
+    icon="book-open"
+    href="/api-reference/introduction"
+  >
     Endpoints, parameters, and the OpenAPI schema.
   </Card>
 </CardGroup>
@@ -119,13 +146,17 @@ Not a coding agent installing a skill — an autonomous agent, RAG pipeline, or 
     - Real-time streaming endpoint: `wss://api.fish.audio/v1/tts/live`
   </Accordion>
 
-  <Accordion title="Retrieval order">
-    1. Read [llms.txt](https://docs.fish.audio/llms.txt) for the curated documentation index.
-    2. Read [llms-full.txt](https://docs.fish.audio/llms-full.txt) when broad site context is needed.
-    3. Read [OpenAPI](https://docs.fish.audio/api-reference/openapi.json) for REST schemas, parameters, and examples.
-    4. Read [AsyncAPI](https://docs.fish.audio/api-reference/asyncapi.yml) for the WebSocket streaming protocol.
-    5. Fetch individual `.md` pages only after narrowing to a specific task.
-  </Accordion>
+<Accordion title="Retrieval order">
+  1. Read [llms.txt](https://docs.fish.audio/llms.txt) for the curated
+  documentation index. 2. Read
+  [llms-full.txt](https://docs.fish.audio/llms-full.txt) when broad site context
+  is needed. 3. Read
+  [OpenAPI](https://docs.fish.audio/api-reference/openapi.json) for REST
+  schemas, parameters, and examples. 4. Read
+  [AsyncAPI](https://docs.fish.audio/api-reference/asyncapi.yml) for the
+  WebSocket streaming protocol. 5. Fetch individual `.md` pages only after
+  narrowing to a specific task.
+</Accordion>
 
   <Accordion title="High-value URLs by task">
     **API specs**
@@ -158,15 +189,17 @@ Not a coding agent installing a skill — an autonomous agent, RAG pipeline, or 
     - [Choosing a Model](https://docs.fish.audio/developer-guide/models-pricing/choosing-a-model.md)
     - [Pricing & Rate Limits](https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits.md)
     - [Model Deprecations](https://docs.fish.audio/developer-guide/models-pricing/deprecations.md)
+
   </Accordion>
 
-  <Accordion title="Task routing">
-    - **Generate speech** → Quick Start, the Text to Speech guide, and `POST /v1/tts`.
-    - **Transcribe audio** → the Speech to Text guide and `POST /v1/asr`.
-    - **Clone or manage voices** → Creating Voice Models and the `/model` endpoints.
-    - **Stream audio in real time** → AsyncAPI, WebSocket TTS Streaming, and the realtime guides.
-    - **Pick a model or estimate cost** → Models Overview and Pricing & Rate Limits.
-  </Accordion>
+<Accordion title="Task routing">
+  - **Generate speech** → Quick Start, the Text to Speech guide, and `POST
+  /v1/tts`. - **Transcribe audio** → the Speech to Text guide and `POST
+  /v1/asr`. - **Clone or manage voices** → Creating Voice Models and the
+  `/model` endpoints. - **Stream audio in real time** → AsyncAPI, WebSocket TTS
+  Streaming, and the realtime guides. - **Pick a model or estimate cost** →
+  Models Overview and Pricing & Rate Limits.
+</Accordion>
 
   <Accordion title="Notes for agents">
     - Prefer `openapi.json` and `asyncapi.yml` for machine-readable schemas.

--- a/developer-guide/resources/coding-agents.mdx
+++ b/developer-guide/resources/coding-agents.mdx
@@ -1,7 +1,7 @@
 ---
-title: "AI Coding Agents"
+title: "AI Coding Assistants"
 description: "Install the Fish Audio skill so your coding agent writes correct SDK and API code"
-icon: "robot"
+icon: "laptop-code"
 ---
 
 import { AudioTranscript } from "/snippets/audio-transcript.jsx";

--- a/docs.json
+++ b/docs.json
@@ -54,10 +54,7 @@
           },
           {
             "group": "Platform (Web App)",
-            "pages": [
-              "overview/platform",
-              "overview/mcp"
-            ]
+            "pages": ["overview/platform", "overview/mcp"]
           },
           {
             "group": "Models & Pricing",
@@ -66,6 +63,68 @@
               "developer-guide/models-pricing/choosing-a-model",
               "developer-guide/models-pricing/deprecations",
               "developer-guide/models-pricing/pricing-and-rate-limits"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Agents",
+        "groups": [
+          {
+            "group": "Get Started",
+            "pages": ["agents/overview", "agents/quickstart", "agents/concepts"]
+          },
+          {
+            "group": "Build",
+            "pages": [
+              "agents/build/configuration",
+              "agents/build/voice-language",
+              "agents/build/time-timezone",
+              "agents/build/knowledge-base",
+              {
+                "group": "Tools",
+                "icon": "wrench",
+                "pages": [
+                  "agents/build/tools",
+                  "agents/build/webhook-tools",
+                  "agents/build/client-tools",
+                  "agents/build/system-tools"
+                ]
+              },
+              "agents/build/dynamic-variables"
+            ]
+          },
+          {
+            "group": "Test",
+            "pages": ["agents/test/preview-calls", "agents/test/agent-tests"]
+          },
+          {
+            "group": "Deploy",
+            "pages": [
+              "agents/deploy/overview",
+              "agents/deploy/versions-publishing",
+              "agents/deploy/authentication",
+              "agents/deploy/public-agents",
+              "agents/deploy/widget",
+              "agents/deploy/web-sdk",
+              "agents/deploy/react-sdk",
+              "agents/deploy/protocol"
+            ]
+          },
+          {
+            "group": "Telephony",
+            "pages": [
+              "agents/telephony/phone-numbers",
+              "agents/telephony/inbound-calls",
+              "agents/telephony/transfers"
+            ]
+          },
+          {
+            "group": "Monitor",
+            "pages": [
+              "agents/monitor/conversation-history",
+              "agents/monitor/post-call-analysis",
+              "agents/monitor/webhooks"
             ]
           }
         ]
@@ -203,8 +262,76 @@
               {
                 "group": "Voice Design",
                 "icon": "wand-magic-sparkles",
+                "pages": ["api-reference/endpoint/openapi-v1/voice-design"]
+              }
+            ]
+          },
+          {
+            "group": "Agents API",
+            "pages": [
+              "api-reference/agent-errors",
+              {
+                "group": "Agents",
+                "icon": "robot",
                 "pages": [
-                  "api-reference/endpoint/openapi-v1/voice-design"
+                  "api-reference/endpoint/agent/list-agents",
+                  "api-reference/endpoint/agent/create-agent",
+                  "api-reference/endpoint/agent/get-agent",
+                  "api-reference/endpoint/agent/update-agent",
+                  "api-reference/endpoint/agent/delete-agent",
+                  "api-reference/endpoint/agent/get-draft-config",
+                  "api-reference/endpoint/agent/update-draft-config",
+                  "api-reference/endpoint/agent/publish-agent",
+                  "api-reference/endpoint/agent/list-agent-versions",
+                  "api-reference/endpoint/agent/get-agent-version",
+                  "api-reference/endpoint/agent/get-widget-config"
+                ]
+              },
+              {
+                "group": "Sessions",
+                "icon": "headset",
+                "pages": [
+                  "api-reference/endpoint/agent/create-agent-session",
+                  "api-reference/endpoint/agent/list-agent-sessions",
+                  "api-reference/endpoint/agent/get-agent-session",
+                  "api-reference/endpoint/agent/get-agent-session-recording",
+                  "api-reference/endpoint/agent/end-agent-session"
+                ]
+              },
+              {
+                "group": "Tools",
+                "icon": "wrench",
+                "pages": [
+                  "api-reference/endpoint/agent/list-tools",
+                  "api-reference/endpoint/agent/create-tool",
+                  "api-reference/endpoint/agent/get-tool",
+                  "api-reference/endpoint/agent/update-tool",
+                  "api-reference/endpoint/agent/delete-tool",
+                  "api-reference/endpoint/agent/list-agents-using-tool"
+                ]
+              },
+              {
+                "group": "Knowledge Sources",
+                "icon": "book",
+                "pages": [
+                  "api-reference/endpoint/agent/list-knowledge-sources",
+                  "api-reference/endpoint/agent/create-knowledge-source",
+                  "api-reference/endpoint/agent/get-knowledge-source",
+                  "api-reference/endpoint/agent/update-knowledge-source",
+                  "api-reference/endpoint/agent/delete-knowledge-source",
+                  "api-reference/endpoint/agent/list-agents-using-knowledge-source"
+                ]
+              },
+              {
+                "group": "Phone Numbers",
+                "icon": "phone",
+                "pages": [
+                  "api-reference/endpoint/agent/search-available-phone-numbers",
+                  "api-reference/endpoint/agent/list-phone-numbers",
+                  "api-reference/endpoint/agent/purchase-phone-number",
+                  "api-reference/endpoint/agent/get-phone-number",
+                  "api-reference/endpoint/agent/update-phone-number",
+                  "api-reference/endpoint/agent/release-phone-number"
                 ]
               }
             ]
@@ -235,9 +362,7 @@
               {
                 "group": "JavaScript SDK",
                 "icon": "js",
-                "pages": [
-                  "api-reference/sdk/javascript/api-reference"
-                ]
+                "pages": ["api-reference/sdk/javascript/api-reference"]
               }
             ]
           }
@@ -270,13 +395,7 @@
     "drilldown": true
   },
   "contextual": {
-    "options": [
-      "copy",
-      "view",
-      "chatgpt",
-      "claude",
-      "perplexity"
-    ]
+    "options": ["copy", "view", "chatgpt", "claude", "perplexity"]
   },
   "fonts": {
     "family": "Onest"
@@ -356,7 +475,7 @@
     },
     {
       "source": "/agents",
-      "destination": "/developer-guide/resources/agent-quickstart"
+      "destination": "/agents/overview"
     },
     {
       "source": "/agent-quickstart",

--- a/llms.txt
+++ b/llms.txt
@@ -4,9 +4,9 @@
 
 ## Start Here
 
-- [Agent Quickstart](https://docs.fish.audio/developer-guide/resources/agent-quickstart.md): Minimal-noise entry point for AI agents with retrieval order, canonical URLs, and task routing.
+- [Coding Assistant Quickstart](https://docs.fish.audio/developer-guide/resources/agent-quickstart.md): Minimal-noise entry point for AI coding assistants with retrieval order, canonical URLs, and task routing.
 - [Quick Start](https://docs.fish.audio/developer-guide/getting-started/quickstart.md): Generate your first AI voice with Fish Audio in under 5 minutes.
-- [AI Coding Agents](https://docs.fish.audio/developer-guide/resources/coding-agents.md): Connect AI coding assistants to Fish Audio documentation via MCP for real-time API guidance.
+- [AI Coding Assistants](https://docs.fish.audio/developer-guide/resources/coding-agents.md): Install the Fish Audio skill so your coding agent writes correct SDK and API code.
 
 ## API Specs
 
@@ -52,6 +52,37 @@
 - [Japanese Phoneme Control](https://docs.fish.audio/developer-guide/core-features/fine-grained-control/japanese.md): Control Japanese pronunciation with romaji phonemes and pitch accent markers.
 - [Voice Cloning Best Practices](https://docs.fish.audio/developer-guide/best-practices/voice-cloning.md): Improve voice cloning quality and consistency.
 - [Real-time Voice Streaming](https://docs.fish.audio/developer-guide/best-practices/real-time-streaming.md): Stream voice generation in real time for interactive applications.
+
+## Voice Agents
+
+- [Agents Overview](https://docs.fish.audio/agents/overview.md): The Fish Audio voice-agent platform — build agents in the console, integrate via REST API and web SDK.
+- [Agents Quickstart](https://docs.fish.audio/agents/quickstart.md): Create, test, and publish your first voice agent via the dashboard or the API.
+- [Agent Concepts](https://docs.fish.audio/agents/concepts.md): Workspaces, agents, draft and published versions, and sessions.
+- [Agent Configuration](https://docs.fish.audio/agents/build/configuration.md): System prompt, first message modes, and draft autosave.
+- [Voice & Language](https://docs.fish.audio/agents/build/voice-language.md): Choose the agent's voice profile and speaking language.
+- [Time & Timezone](https://docs.fish.audio/agents/build/time-timezone.md): Agents know the current date and time by default; timezone resolution and opt-out.
+- [Knowledge Base](https://docs.fish.audio/agents/build/knowledge-base.md): Attach documents so the agent can answer from your content.
+- [Tools Overview](https://docs.fish.audio/agents/build/tools.md): Webhook, client, and system tools for voice agents.
+- [Webhook Tools](https://docs.fish.audio/agents/build/webhook-tools.md): Let the agent call your HTTP endpoints, with templating and testing.
+- [Client Tools](https://docs.fish.audio/agents/build/client-tools.md): Tools your app executes in the browser through the SDK.
+- [System Tools](https://docs.fish.audio/agents/build/system-tools.md): Built-in language detection and hang-up capabilities.
+- [Dynamic Variables & Overrides](https://docs.fish.audio/agents/build/dynamic-variables.md): Personalize each session with variables and whitelisted overrides.
+- [Versions & Publishing](https://docs.fish.audio/agents/deploy/versions-publishing.md): Draft, publish, clone, and restore agent configurations.
+- [Deployment Overview](https://docs.fish.audio/agents/deploy/overview.md): Pick a deployment channel — widget, public agents, authenticated sessions, or a phone number.
+- [Authentication & Session Tokens](https://docs.fish.audio/agents/deploy/authentication.md): Public agent IDs vs server-minted session tokens; POST /v1/agent/sessions.
+- [Public Agents](https://docs.fish.audio/agents/deploy/public-agents.md): Credential-free browser access with an origin allowlist.
+- [Web SDK](https://docs.fish.audio/agents/deploy/web-sdk.md): @fishaudio/agent-client — events, modes, transcripts, audio controls, and errors.
+- [React SDK](https://docs.fish.audio/agents/deploy/react-sdk.md): React hooks and components for voice-agent UIs.
+- [Widget](https://docs.fish.audio/agents/deploy/widget.md): Embed a complete voice and chat UI on any website with two lines of HTML — no build step.
+- [Wire Protocol](https://docs.fish.audio/agents/deploy/protocol.md): The realtime message protocol for non-SDK consumers.
+- [Phone Numbers](https://docs.fish.audio/agents/telephony/phone-numbers.md): Manage phone numbers and bind them to agents.
+- [Inbound Calls](https://docs.fish.audio/agents/telephony/inbound-calls.md): Answer phone calls with an agent and track caller attribution.
+- [Call Transfers](https://docs.fish.audio/agents/telephony/transfers.md): Let the agent hand a phone call to a human — cold carrier handoff or warm transfer with a private briefing.
+- [Preview Calls](https://docs.fish.audio/agents/test/preview-calls.md): Test your draft agent by voice inside the Builder.
+- [Agent Tests](https://docs.fish.audio/agents/test/agent-tests.md): Scripted next-reply tests scored by an LLM judge.
+- [Conversation History](https://docs.fish.audio/agents/monitor/conversation-history.md): Query sessions, transcripts, tool timelines, and recordings via the API.
+- [Post-call Analysis](https://docs.fish.audio/agents/monitor/post-call-analysis.md): Automatic summaries, data extraction, and success criteria.
+- [Agent Webhooks](https://docs.fish.audio/agents/monitor/webhooks.md): call.ended and call.analyzed events with HMAC signature verification.
 
 ## Operational Docs
 


### PR DESCRIPTION
## What's included

A full **Agents** section (28 pages) plus the **Agents API reference**:

- **Build** — configuration, voice & language, time & timezone, knowledge base, tools (webhook / client / system), dynamic variables
- **Test** — preview calls, agent tests
- **Deploy** — deployment overview, versions & publishing, authentication, public agents, widget, Web SDK, React SDK, wire protocol
- **Telephony** — phone numbers, inbound calls, transfers
- **Monitor** — conversation history, post-call analysis, webhooks
- **Agents API reference** — 34 endpoint pages rendered from the OpenAPI schema, plus an [error reference](https://docs.fish.audio/api-reference/agent-errors) covering every status the `/v1/agent` surface returns
- llms.txt index entries and navigation wiring

## Verification

Every factual claim was checked against platform-api, fish-agent, and the web SDK in two review passes — an automated cross-check of all pages plus a manual read-through — covering payload shapes, defaults, limits, endpoint paths, and error semantics. `mint broken-links` reports zero issues on the pages this PR touches, and the bundled `api-reference/openapi.json` is byte-identical to main's current snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788522777&installation_model_id=430858&pr_number=116&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F116&signature=75cf6d1171751e3e392353ef925e422400f2047310ce38bfad96d25386a1ff00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive voice-agent documentation covering configuration, tools, knowledge bases, deployment, SDKs, authentication, telephony, testing, monitoring, and publishing.
  - Added guides for public agents, web and React integrations, widgets, conversation history, post-call analysis, and webhooks.
  - Expanded API reference coverage for agent, session, tool, knowledge-source, phone-number, and publishing operations.
- **Documentation**
  - Added a central Agents overview, quickstart, core concepts, error reference, and updated navigation.
  - Updated coding-assistant terminology and improved related page formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->