### PR TITLE
docs: restructure agents Deploy section around surface × access mode

### DIFF
--- a/agents/build/configuration.mdx
+++ b/agents/build/configuration.mdx
@@ -62,7 +62,7 @@ The Voice panel selects the voice profile your agent speaks with (`voice_profile
 
 ### Recording
 
-`conversation.record_audio` (default `true`) — store per-speaker audio for [playback and download](/agents/monitor/conversation-history#what-gets-stored), with a per-session override on the [session request](/agents/deploy/authentication). In the console this lives under your agent's **Settings**. Recording defaults to on — make sure callers are informed and consent where your jurisdiction requires it.
+`conversation.record_audio` (default `true`) — store per-speaker audio for [playback and download](/agents/monitor/conversation-history#what-gets-stored), with a per-session override on the [session request](/agents/deploy/authenticated-sessions). In the console this lives under your agent's **Settings**. Recording defaults to on — make sure callers are informed and consent where your jurisdiction requires it.
 
 ### Timezone
 
@@ -80,7 +80,6 @@ The same draft is readable and writable over REST — useful for provisioning ag
 
 ### Read the draft
 
-<CodeGroup>
 ```bash Request
 curl --request GET "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
   --header "Authorization: Bearer $FISH_API_KEY"
@@ -107,7 +106,6 @@ curl --request GET "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
   }
 }
 ```
-</CodeGroup>
 
 The response also includes the `tools`, `knowledge_base`, `analysis`, and `webhooks` sections, each covered on its own page. `config_hash` identifies this draft revision — it changes whenever an edit changes the draft's content, and a mismatch with the published version is what marks an agent as having unpublished changes.
 

--- a/agents/build/dynamic-variables.mdx
+++ b/agents/build/dynamic-variables.mdx
@@ -107,7 +107,7 @@ The session record stores which overrides took effect.
 
 ## Who supplies the values
 
-Where variables and overrides come from depends on how the session is [authenticated](/agents/deploy/authentication):
+Where variables and overrides come from depends on the session's [access mode](/agents/deploy/overview#who-may-start-sessions):
 
 | Mode | Who creates the session | Who supplies variables and overrides |
 |---|---|---|
@@ -143,8 +143,12 @@ In `agentId` mode, values arrive from the end user's browser — treat them as u
   <Card title="Agent configuration" icon="sliders" href="/agents/build/configuration">
     The fields your placeholders and overrides act on.
   </Card>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
-    API keys, session tokens, and the two session modes.
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
+    Set variables from your backend when creating the session.
   </Card>
   <Card title="Versions & publishing" icon="code-branch" href="/agents/deploy/versions-publishing">
     Sessions assemble the published configuration.

--- a/agents/build/knowledge-base.mdx
+++ b/agents/build/knowledge-base.mdx
@@ -84,7 +84,6 @@ Knowledge sources are exposed at `/v1/agent/knowledge-sources`. Only workspace s
 | `DELETE /v1/agent/knowledge-sources/{source_id}` | Delete a source |
 | `GET /v1/agent/knowledge-sources/{source_id}/agents` | List agents that attach the source |
 
-<CodeGroup>
 ```bash Create a source
 curl --request POST https://api.fish.audio/v1/agent/knowledge-sources \
   --header "Authorization: Bearer $FISH_API_KEY" \
@@ -103,7 +102,6 @@ curl --request PATCH https://api.fish.audio/v1/agent/knowledge-sources/{source_i
 curl https://api.fish.audio/v1/agent/knowledge-sources/{source_id}/agents \
   --header "Authorization: Bearer $FISH_API_KEY"
 ```
-</CodeGroup>
 
 Only the `source` file part is required on create — `name` falls back to the uploaded file's name.
 

--- a/agents/build/time-timezone.mdx
+++ b/agents/build/time-timezone.mdx
@@ -34,7 +34,7 @@ The timezone is resolved once, when the session is created, taking the first tha
 
 In the browser, this means zero configuration: the SDK detects the visitor's real timezone and the agent talks about "today" in the user's local terms, not yours.
 
-With [session token](/agents/deploy/authentication) auth, the SDK's automatic hint doesn't apply — your backend creates the session, so set `timezone` (or forward the browser's value as `client_timezone`) in the creation request:
+With [authenticated sessions](/agents/deploy/authenticated-sessions), the SDK's automatic hint doesn't apply — your backend creates the session, so set `timezone` (or forward the browser's value as `client_timezone`) in the creation request:
 
 ```bash API (curl)
 curl --request POST https://api.fish.audio/v1/agent/sessions \
@@ -82,9 +82,9 @@ const session = await AgentSession.start({
 
 <CardGroup cols={2}>
   <Card
-    title="Authentication"
-    icon="key"
-    href="/agents/deploy/authentication"
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
   >
     All session-creation parameters, including `timezone` and `world_context`.
   </Card>

--- a/agents/build/tools.mdx
+++ b/agents/build/tools.mdx
@@ -48,7 +48,7 @@ Over the API, `DELETE` is stricter: it returns `409` while the tool is still att
 
 ## Manage tools over the API
 
-Every endpoint requires your API key — see [Authentication](/agents/deploy/authentication).
+Every endpoint requires your API key — see the [API introduction](/api-reference/introduction).
 
 | Endpoint | Description |
 |---|---|
@@ -102,7 +102,7 @@ Field-level configuration — custom headers, request body templates, timeouts, 
   <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
     Register client tool handlers in your application.
   </Card>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+  <Card title="API introduction" icon="key" href="/api-reference/introduction">
     API keys for the endpoints above.
   </Card>
 </CardGroup>

--- a/agents/concepts.mdx
+++ b/agents/concepts.mdx
@@ -20,7 +20,7 @@ curl https://api.fish.audio/v1/agent/agents \
   --header "Authorization: Bearer $FISH_API_KEY"
 ```
 
-See [Authentication](/agents/deploy/authentication) for key setup.
+Create keys under [API keys](https://fish.audio/app/api-keys/) in the console.
 
 ## Agents
 

--- a/agents/deploy/authenticated-sessions.mdx
+++ b/agents/deploy/authenticated-sessions.mdx
@@ -1,47 +1,29 @@
 ---
-title: "Authentication"
-description: "Connect clients to your agent with a public agent ID or a backend-minted session token"
-icon: "key"
+title: "Authenticated Sessions"
+description: "Create short-lived session tokens on your backend and run private agents in any client"
+icon: "server"
 ---
 
-There are exactly two ways for a client to start a conversation with your agent. Pick one — there is no third path, and your API key is never one of them in the browser.
+An authenticated session starts on your server: your backend calls the session endpoint with your API key and receives a short-lived **session token**, which your client uses to connect. The API key never leaves your server, and every session parameter — user identity, overrides, dynamic variables — is set by code you trust. This is how private agents run in production.
 
-<CardGroup cols={2}>
-  <Card title="Public agent ID" icon="globe">
-    The browser calls Fish Audio directly with just an `agentId`. No credential
-    — requires the agent to be [public](/agents/deploy/public-agents).
-  </Card>
-  <Card title="Session token" icon="server">
-    Your backend creates a session with your API key and hands the short-lived
-    token to the SDK. The default for private agents.
-  </Card>
-</CardGroup>
+The token is client-agnostic. Create it the same way regardless of which surface renders the conversation:
 
-|                           | Public agent ID                                                             | Session token                         |
-| ------------------------- | --------------------------------------------------------------------------- | ------------------------------------- |
-| Credential in browser     | None                                                                        | Short-lived session token             |
-| Requires                  | Agent set to public + allowed origins                                       | Your own backend endpoint             |
-| Session parameters set by | The SDK (`overrides`, `dynamicVariables`, `language`, `toolEvents` options) | Your backend, in the creation request |
-| Best for                  | Demos, marketing pages, low-friction embeds                                 | Production apps with signed-in users  |
+| Client                                         | Where the token goes                                                                             |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [Web SDK](/agents/deploy/web-sdk)              | `AgentSession.start({ sessionToken })`                                                           |
+| [React SDK](/agents/deploy/react-sdk)          | `startSession({ sessionToken })`                                                                 |
+| [Widget](/agents/deploy/widget#private-agents) | Returned from `sessionTokenProvider`                                                             |
+| [Custom client](/agents/deploy/protocol)       | Connect to the transport named in the response, per the [wire protocol](/agents/deploy/protocol) |
 
-## Public agents: connect with an agent ID
+<Note>
+  No backend, and anyone may talk to the agent? A [public
+  agent](/agents/deploy/public-agents) lets the SDK create sessions with just an
+  `agentId` — no token involved, gated by an origin allowlist and rate limits.
+</Note>
 
-If the agent is public, the SDK creates the session itself — no backend, no credential:
+## Create a token on your backend
 
-```javascript JavaScript
-import { AgentSession } from "@fishaudio/agent-client";
-
-const session = await AgentSession.start({
-  agentId: "YOUR_AGENT_ID",
-  dynamicVariables: { name: "Ada" },
-});
-```
-
-Fish Audio accepts the request only when the agent has public access enabled and the page's `Origin` is on the agent's allow-list; requests are rate-limited per IP and per agent. Origins match on exact scheme, host, and port — `localhost` and `127.0.0.1` are different origins, so list both during development. See [Public agents](/agents/deploy/public-agents) for setup.
-
-## Session tokens: mint on your backend
-
-For private agents, your backend exchanges your API key for a single-conversation token.
+Your backend exchanges your API key for a single-conversation token.
 
 <Steps>
   <Step title="Create a session from your backend">
@@ -51,7 +33,7 @@ For private agents, your backend exchanges your API key for a single-conversatio
   <Step title="Return the response to your frontend">
     The response is the session token. Forward it verbatim.
   </Step>
-  <Step title="Start the SDK with the token">
+  <Step title="Start the client with the token">
     Pass the object to `AgentSession.start({sessionToken})` unmodified. The SDK
     handles the connection from there.
   </Step>
@@ -109,6 +91,10 @@ def create_voice_session(end_user_id: str, name: str) -> dict:
     return response.json()
 ```
 
+</CodeGroup>
+
+On the client, fetch the token from your backend and pass it to the SDK unchanged:
+
 ```javascript Browser
 import { AgentSession } from "@fishaudio/agent-client";
 
@@ -119,16 +105,15 @@ const sessionToken = await fetch("/voice-session", { method: "POST" }).then(r =>
 const session = await AgentSession.start({ sessionToken });
 ```
 
-</CodeGroup>
+More on what the SDK can do once connected is in the [Web SDK](/agents/deploy/web-sdk) reference.
 
 <Note>
-  In session token mode, `overrides`, `dynamic_variables`, `language`,
-  `tool_events`, `timezone`, and `world_context` belong in your backend's
-  creation request — the SDK forwards these options only in public agent ID
-  mode.
+  `overrides`, `dynamic_variables`, `language`, `tool_events`, `timezone`, and
+  `world_context` belong in your backend's creation request — the SDK forwards
+  these options only in [public agent](/agents/deploy/public-agents) mode.
 </Note>
 
-### Request fields
+## Request fields
 
 | Field               | Type              | Description                                                                                                                                                                                                                                                                               |
 | ------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -147,7 +132,7 @@ const session = await AgentSession.start({ sessionToken });
 
 Unknown fields — top-level or inside `overrides` — are rejected with `422`.
 
-### Response
+## Response
 
 ```json JSON
 {
@@ -163,20 +148,20 @@ Unknown fields — top-level or inside `overrides` — are rejected with `422`.
 | Field                  | Description                                                                                                 |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `session_id`           | The session's id — use it later to look up the [conversation record](/agents/monitor/conversation-history). |
-| `expires_at`           | Deadline for the client to connect. Mint the token right before starting, not ahead of time.                |
+| `expires_at`           | Deadline for the client to connect. Create the token right before starting, not ahead of time.              |
 | `max_duration_seconds` | Hard cap on session length.                                                                                 |
 | `transport`            | Which transport the SDK uses for this session; `livekit` today.                                             |
 | `livekit_url`, `token` | Connection details for that transport, consumed by the SDK.                                                 |
 
 Treat the response as opaque and pass it to `start()` unmodified. If the SDK does not recognize the `transport` value, it fails fast with an `unsupported_transport` error asking you to upgrade the SDK — it never silently degrades.
 
-### Token lifetime
+## Token lifetime
 
 - A session token is **single-use**: `start()` consumes it once to establish the conversation.
-- On network drops the SDK reconnects at the transport level using the same connection state — it never re-creates the session, so you never need to re-mint mid-call.
-- Once a session ends, the token is spent. Mint a new token for each conversation.
+- On network drops the SDK reconnects at the transport level using the same connection state — it never re-creates the session, so you never need a fresh token mid-call.
+- Once a session ends, the token is spent. Create a new token for each conversation.
 
-### Ending sessions from your backend
+## Ending sessions from your backend
 
 A session normally ends from the client side — the user disconnects, or the agent [hangs up](/agents/build/system-tools). To force-end a live session server-side, call the end endpoint with your API key and the `session_id` from the creation response:
 
@@ -216,13 +201,17 @@ The complete status-code reference for every `/v1/agent` endpoint — error shap
 
 <CardGroup cols={2}>
   <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
-    Enable credential-free access with origin allow-lists.
+    The credential-free alternative, with origin allow-lists.
+  </Card>
+  <Card
+    title="Widget with private agents"
+    icon="puzzle-piece"
+    href="/agents/deploy/widget#private-agents"
+  >
+    Feed the widget session tokens from your backend via `sessionTokenProvider`.
   </Card>
   <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
     Everything `AgentSession` can do once connected.
-  </Card>
-  <Card title="React SDK" icon="react" href="/agents/deploy/react-sdk">
-    Hooks and components for React apps.
   </Card>
   <Card
     title="Dynamic variables"

--- a/agents/deploy/overview.mdx
+++ b/agents/deploy/overview.mdx
@@ -1,11 +1,16 @@
 ---
 title: "Deploy Your Agent"
 sidebarTitle: "Overview"
-description: "Pick a deployment channel — embeddable widget, public agents, authenticated sessions, or a phone number"
+description: "Choose where users meet your agent and who may start sessions — widget, SDKs, or phone; public or authenticated"
 icon: "plug"
 ---
 
-Your agent is one artifact with many front doors. Deployment is a ladder: start with the zero-code widget and climb only as far as your needs require — browser access without a backend, backend-minted sessions, or a phone number. Every channel runs the same agent with the same configuration.
+Your agent is one artifact with many front doors. Deploying it is two independent decisions:
+
+1. **Where users meet your agent** — a prebuilt widget, your own UI built on the SDKs, a phone number, or a custom client.
+2. **Who may start sessions** — anyone visiting your pages, or only clients your backend has vouched for.
+
+Every surface runs the same agent with the same published configuration, and the browser surfaces work with either access mode.
 
 <Note>
   Publishing gates every channel: sessions always run the agent's **published**
@@ -14,58 +19,74 @@ Your agent is one artifact with many front doors. Deployment is a ladder: start 
   up any channel.
 </Note>
 
-## Choose a channel
+## Where users meet your agent
 
-In increasing order of integration effort and control:
+In increasing order of integration effort:
 
 <CardGroup cols={2}>
-  <Card
-    title="1. Embeddable widget"
-    icon="puzzle-piece"
-    href="/agents/deploy/widget"
-  >
-    Drop a prebuilt call widget into your site — zero code.
+  <Card title="Widget" icon="puzzle-piece" href="/agents/deploy/widget">
+    Drop a prebuilt call widget into your site — two lines of HTML, zero build
+    step.
   </Card>
-  <Card
-    title="2. Public agents"
-    icon="globe"
-    href="/agents/deploy/public-agents"
-  >
-    Browser-only: the SDK connects with just an `agentId`, gated by an origin
-    allowlist and rate limits.
+  <Card title="Your own UI" icon="js" href="/agents/deploy/web-sdk">
+    Build a custom experience with the [Web SDK](/agents/deploy/web-sdk) or
+    [React SDK](/agents/deploy/react-sdk) — events, transcripts, audio controls.
   </Card>
-  <Card
-    title="3. Authenticated sessions"
-    icon="server"
-    href="/agents/deploy/authentication"
-  >
-    Your backend mints a session token; the Web or React SDK takes it from
-    there.
-  </Card>
-  <Card title="4. Phone" icon="phone" href="/agents/telephony/phone-numbers">
+  <Card title="Phone" icon="phone" href="/agents/telephony/phone-numbers">
     Bind a number and callers dial straight in — no client code at all.
+  </Card>
+  <Card
+    title="Custom client"
+    icon="network-wired"
+    href="/agents/deploy/protocol"
+  >
+    On a stack the SDKs don't cover, implement the [wire
+    protocol](/agents/deploy/protocol) directly.
   </Card>
 </CardGroup>
 
-Building a client on a stack the SDKs don't cover? The [wire protocol](/agents/deploy/protocol) documents the wire-level session contract.
+## Who may start sessions
 
-Still deciding?
+The widget and the SDKs each work with **either** access mode — pick per agent. Phone numbers skip this decision entirely: inbound calls connect through [telephony](/agents/telephony/inbound-calls), not a browser session.
 
-| You are building                                   | Start with                                                                                                       |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| A call button on an existing site, no build step   | [Widget](/agents/deploy/widget)                                                                                  |
-| A demo or marketing page without a backend         | [Public agents](/agents/deploy/public-agents)                                                                    |
-| Voice calls inside a web app                       | [Authentication](/agents/deploy/authentication) and the [Web SDK](/agents/deploy/web-sdk)                        |
-| A React or Next.js frontend                        | [React SDK](/agents/deploy/react-sdk)                                                                            |
-| A phone line callers dial in to                    | [Phone numbers](/agents/telephony/phone-numbers) and [transfers](/agents/telephony/transfers)                    |
-| Server-side session creation and history retrieval | [Authentication](/agents/deploy/authentication) and [conversation history](/agents/monitor/conversation-history) |
-| A client on a stack the SDKs don't cover           | [Wire protocol](/agents/deploy/protocol)                                                                         |
+<CardGroup cols={2}>
+  <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
+    The client connects with just an `agentId` — no backend, gated by an origin
+    allowlist and rate limits.
+  </Card>
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
+    Your backend creates a short-lived session token with your API key — trusted
+    attribution and full control.
+  </Card>
+</CardGroup>
+
+|                           | Public agent ID                                                             | Session token                         |
+| ------------------------- | --------------------------------------------------------------------------- | ------------------------------------- |
+| Credential in browser     | None                                                                        | Short-lived session token             |
+| Requires                  | Agent set to public + allowed origins                                       | Your own backend endpoint             |
+| Session parameters set by | The SDK (`overrides`, `dynamicVariables`, `language`, `toolEvents` options) | Your backend, in the creation request |
+| Best for                  | Demos, marketing pages, low-friction embeds                                 | Production apps with signed-in users  |
+
+## Still deciding?
+
+| You are building                                   | Start with                                                                                                                       |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| A call button on an existing site, no build step   | [Widget](/agents/deploy/widget) with [public access](/agents/deploy/public-agents)                                               |
+| A demo or marketing page without a backend         | [Web SDK](/agents/deploy/web-sdk) on a [public agent](/agents/deploy/public-agents)                                              |
+| Voice calls inside a web app with signed-in users  | [Web SDK](/agents/deploy/web-sdk) with [authenticated sessions](/agents/deploy/authenticated-sessions)                           |
+| A React or Next.js frontend                        | [React SDK](/agents/deploy/react-sdk)                                                                                            |
+| A phone line callers dial in to                    | [Phone numbers](/agents/telephony/phone-numbers) and [transfers](/agents/telephony/transfers)                                    |
+| Server-side session creation and history retrieval | [Authenticated sessions](/agents/deploy/authenticated-sessions) and [conversation history](/agents/monitor/conversation-history) |
+| A client on a stack the SDKs don't cover           | [Wire protocol](/agents/deploy/protocol)                                                                                         |
 
 ## How a browser session starts
 
 For private agents, your backend creates the session — your API key never ships to the browser. The browser SDK takes the resulting session token and handles audio and transport from there.
 
-<CodeGroup>
 ```bash Your backend
 curl --request POST https://api.fish.audio/v1/agent/sessions \
   --header "Authorization: Bearer $FISH_API_KEY" \
@@ -80,8 +101,6 @@ import { AgentSession } from "@fishaudio/agent-client";
 // sessionToken = the create-session response, passed through unchanged
 const session = await AgentSession.start({ sessionToken });
 ```
-
-</CodeGroup>
 
 <Tip>
   Agents marked [public](/agents/deploy/public-agents) skip the backend step
@@ -101,8 +120,13 @@ For phone calls there is no client integration: assign a number, and inbound cal
   >
     The publish step every channel depends on.
   </Card>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
-    API keys, session tokens, and which one belongs where.
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
+    The full session-creation reference — request fields, token lifetime,
+    errors.
   </Card>
   <Card
     title="Conversation history"

--- a/agents/deploy/protocol.mdx
+++ b/agents/deploy/protocol.mdx
@@ -23,7 +23,7 @@ npm install @fishaudio/agent-protocol
 
 ## Connect to a session
 
-Create a session server-side ([authentication](/agents/deploy/authentication)), then connect to the transport named in the response. [Public agents](/agents/deploy/public-agents) can create sessions without the `Authorization` header.
+Create a session server-side ([authenticated sessions](/agents/deploy/authenticated-sessions)), then connect to the transport named in the response. [Public agents](/agents/deploy/public-agents) can create sessions without the `Authorization` header.
 
 ```bash Create a session
 curl --request POST https://api.fish.audio/v1/agent/sessions \
@@ -166,7 +166,11 @@ These ride the transport's built-in mechanisms rather than custom messages.
   <Card title="Client tools" icon="wrench" href="/agents/build/client-tools">
     Declare the tools your `client_tool.call` handlers implement.
   </Card>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
     Session creation, API keys, and token handling.
   </Card>
   <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">

--- a/agents/deploy/public-agents.mdx
+++ b/agents/deploy/public-agents.mdx
@@ -6,7 +6,7 @@ icon: "globe"
 
 A public agent accepts sessions straight from the browser: the SDK calls the session endpoint with just an `agent_id` — no API key, no server of your own. The platform gates access with three controls: an agent-level public switch (off by default), a required origin allowlist, and rate limiting.
 
-Use this mode for demos, marketing pages, and support bubbles where standing up a backend isn't worth it. For production apps with their own users, [session tokens](/agents/deploy/authentication) are usually the better fit — see [when to use session tokens instead](#when-to-use-session-tokens-instead).
+Use this mode for demos, marketing pages, and support bubbles where standing up a backend isn't worth it. For production apps with their own users, [authenticated sessions](/agents/deploy/authenticated-sessions) are usually the better fit — see [when to use session tokens instead](#when-to-use-session-tokens-instead).
 
 ## Enable public access
 
@@ -86,7 +86,7 @@ Public session creation is rate limited on two dimensions at once: per **client 
 
 <Note>
   If legitimate traffic outgrows these limits, or you need per-user quotas, move
-  to [session token authentication](/agents/deploy/authentication) — your
+  to [authenticated sessions](/agents/deploy/authenticated-sessions) — your
   backend becomes the gate, and the platform-side public limits no longer apply.
 </Note>
 
@@ -118,13 +118,17 @@ Public mode trades control for zero setup. Prefer the `sessionToken` flow — yo
 - You want server-side control of `overrides`, `dynamic_variables`, or `tool_events` instead of accepting the browser's values.
 - You already authenticate users and want **your own quotas** per account, not IP-based platform limits.
 
-The SDK call changes by one field — pass `{ sessionToken }` instead of `{ agentId }`. See [Authentication](/agents/deploy/authentication) for the full flow.
+The SDK call changes by one field — pass `{ sessionToken }` instead of `{ agentId }`. See [Authenticated sessions](/agents/deploy/authenticated-sessions) for the full flow.
 
 ## Going further
 
 <CardGroup cols={2}>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
-    Both auth modes side by side, and the session token flow in full.
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
+    The session token flow in full — request fields, lifetime, errors.
   </Card>
   <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
     Events, methods, and client tools — identical in both modes.

--- a/agents/deploy/react-sdk.mdx
+++ b/agents/deploy/react-sdk.mdx
@@ -10,7 +10,11 @@ icon: "react"
   <Card title="Web SDK reference" icon="js" href="/agents/deploy/web-sdk">
     Every event, method, and error code.
   </Card>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
     Create session tokens on your backend.
   </Card>
   <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
@@ -99,7 +103,7 @@ const sessionToken = await res.json();
 await startSession({ sessionToken });
 ```
 
-See [Authentication](/agents/deploy/authentication) for the backend side. `startSession` accepts the same options as `AgentSession.start` in the [Web SDK](/agents/deploy/web-sdk), including [`clientTools`](/agents/build/client-tools). Session settings such as `overrides` and `dynamicVariables` apply when you connect with an `agentId`; with a `sessionToken`, your backend sets them in its session-creation request instead.
+See [Authenticated sessions](/agents/deploy/authenticated-sessions) for the backend side. `startSession` accepts the same options as `AgentSession.start` in the [Web SDK](/agents/deploy/web-sdk), including [`clientTools`](/agents/build/client-tools). Session settings such as `overrides` and `dynamicVariables` apply when you connect with an `agentId`; with a `sessionToken`, your backend sets them in its session-creation request instead.
 
 ## What `useConversation` returns
 
@@ -184,7 +188,11 @@ For a custom visualization, build on `useAudioLevels` or the session's frequency
   <Card title="Client tools" icon="wrench" href="/agents/build/client-tools">
     Let the agent call functions in your app.
   </Card>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
     Create session tokens server-side for private agents.
   </Card>
   <Card

--- a/agents/deploy/versions-publishing.mdx
+++ b/agents/deploy/versions-publishing.mdx
@@ -24,7 +24,7 @@ Every agent has one **draft** and a linear history of **published versions**. Ed
   <Card
     title="Automate via API"
     icon="brackets-curly"
-    href="/agents/deploy/overview"
+    href="/api-reference/endpoint/agent/publish-agent"
   >
     Manage drafts, publishing, and version history programmatically.
   </Card>
@@ -71,7 +71,6 @@ New sessions use the newly published version from that point on. To hear a chang
 
 Configuration edits (`PATCH`) go to the draft; a separate `publish` call rolls them out. A `version_title` and `version_description` are optional and make the version history easier to audit:
 
-<CodeGroup>
 ```bash Update the draft
 curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
   --header "Authorization: Bearer $FISH_API_KEY" \
@@ -88,15 +87,12 @@ curl --request POST "https://api.fish.audio/v1/agent/agents/$AGENT_ID/publish" \
   --data '{ "version_title": "Tighten support tone" }'
 ```
 
-</CodeGroup>
-
 The publish response includes the new `version_number`.
 
 ## Version history
 
 List published versions, or fetch the complete configuration snapshot of any one of them — including the version currently serving production:
 
-<CodeGroup>
 ```bash List versions
 curl "https://api.fish.audio/v1/agent/agents/$AGENT_ID/versions" \
   --header "Authorization: Bearer $FISH_API_KEY"
@@ -106,8 +102,6 @@ curl "https://api.fish.audio/v1/agent/agents/$AGENT_ID/versions" \
 curl "https://api.fish.audio/v1/agent/agents/$AGENT_ID/versions/3" \
   --header "Authorization: Bearer $FISH_API_KEY"
 ```
-
-</CodeGroup>
 
 Each version record includes:
 
@@ -131,7 +125,6 @@ Fetching a single version returns the full configuration as it was published. Be
 
 Roll back by copying an old snapshot back into the draft: read the version you want, then `PATCH` its sections into the draft config.
 
-<CodeGroup>
 ```bash 1. Read the old snapshot
 curl "https://api.fish.audio/v1/agent/agents/$AGENT_ID/versions/2" \
   --header "Authorization: Bearer $FISH_API_KEY"
@@ -143,8 +136,6 @@ curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
   --header "Content-Type: application/json" \
   --data '{ "prompt": { "system_prompt": "<system prompt from the snapshot>" } }'
 ```
-
-</CodeGroup>
 
 Patching updates the draft — it does **not** publish. Review or [preview](/agents/test/preview-calls) the restored draft, then publish it as a new version; the rollback becomes part of the linear history, so the audit trail stays intact. Because snapshots never echo secrets (see above), credential fields keep their current draft values unless you set them again explicitly.
 

--- a/agents/deploy/web-sdk.mdx
+++ b/agents/deploy/web-sdk.mdx
@@ -30,7 +30,7 @@ yarn add @fishaudio/agent-client
 `AgentSession.start()` creates the session, connects, and opens the microphone in one call. Authenticate one of two ways:
 
 - **`agentId`** — for [public agents](/agents/deploy/public-agents). The SDK creates the session directly from the browser; no backend needed.
-- **`sessionToken`** — for private agents. Your backend calls `POST /v1/agent/sessions` with your API key and hands the JSON response to the browser; pass it through unchanged. See [Authentication](/agents/deploy/authentication).
+- **`sessionToken`** — for private agents. Your backend calls `POST /v1/agent/sessions` with your API key and hands the JSON response to the browser; pass it through unchanged. See [Authenticated sessions](/agents/deploy/authenticated-sessions).
 
 <CodeGroup>
 
@@ -258,8 +258,12 @@ await session.end(); // graceful hangup; disconnect fires with reason "user_hang
   <Card title="React SDK" icon="react" href="/agents/deploy/react-sdk">
     Hooks, provider, and visualizer components on top of this SDK.
   </Card>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
-    Mint session tokens from your backend for private agents.
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
+    Create session tokens on your backend for private agents.
   </Card>
   <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
     Backend-free sessions with origin allow-lists and rate limits.

--- a/agents/deploy/widget.mdx
+++ b/agents/deploy/widget.mdx
@@ -96,7 +96,7 @@ React apps pass the same function as a prop:
 <FishAgentWidget sessionTokenProvider={getSessionToken} />
 ```
 
-Your backend holds the API key and creates the session with `POST /v1/agent/sessions`; origin checks, user auth, and rate limiting on that endpoint are yours. See [Authentication](/agents/deploy/authentication) for the token flow and a backend example.
+Your backend holds the API key and creates the session with `POST /v1/agent/sessions`; origin checks, user auth, and rate limiting on that endpoint are yours. See [Authenticated sessions](/agents/deploy/authenticated-sessions) for the token flow and a backend example.
 
 ## Theming
 
@@ -159,7 +159,11 @@ On load, the widget anonymously fetches the agent's console widget settings from
   <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
     The public switch, origin allowlist, and rate limits behind the widget.
   </Card>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
     The session-token flow your `sessionTokenProvider` implements.
   </Card>
   <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">

--- a/agents/monitor/conversation-history.mdx
+++ b/agents/monitor/conversation-history.mdx
@@ -10,7 +10,7 @@ This is a server-side API — authenticate with your API key. The client SDKs de
 
 ## What gets stored
 
-The session record — status, timing, caller attribution, name, and `metadata` — and the conversation transcript are always kept for production sessions. Audio recording is a per-agent choice, on by default: set `conversation.record_audio` in the console under your agent's **Settings** or in the `conversation` section of the [config API](/agents/build/configuration#configure-through-the-api), with a per-session override on the [session request](/agents/deploy/authentication). Recording off means there is no audio to download.
+The session record — status, timing, caller attribution, name, and `metadata` — and the conversation transcript are always kept for production sessions. Audio recording is a per-agent choice, on by default: set `conversation.record_audio` in the console under your agent's **Settings** or in the `conversation` section of the [config API](/agents/build/configuration#configure-through-the-api), with a per-session override on the [session request](/agents/deploy/authenticated-sessions). Recording off means there is no audio to download.
 
 The setting doesn't affect the live call: transcript events still stream to connected clients in real time.
 

--- a/agents/monitor/post-call-analysis.mdx
+++ b/agents/monitor/post-call-analysis.mdx
@@ -173,7 +173,7 @@ curl "https://api.fish.audio/v1/agent/sessions/$SESSION_ID" \
 }
 ```
 
-To push results into your CRM or data warehouse as soon as they're ready, configure a [post-call webhook](/agents/monitor/webhooks) — it fires once analysis completes.
+To push results into your CRM or data warehouse as soon as they're ready, configure a [post-call webhook](/agents/monitor/webhooks) — `call.analyzed` fires as soon as the run settles, whatever the outcome, with `analysis.status` telling you which of the terminal statuses above it reached.
 
 ## Going further
 

--- a/agents/monitor/webhooks.mdx
+++ b/agents/monitor/webhooks.mdx
@@ -1,19 +1,19 @@
 ---
 title: "Webhooks"
-description: "Get an HTTP POST when a call ends and when its analysis completes — no polling"
+description: "Get an HTTP POST when a call ends and when its analysis settles — no polling"
 icon: "bell"
 ---
 
-Point your agent at one or more endpoints on your server and Fish Audio calls them when things happen: `call.ended` the moment a session reaches a terminal state, `call.analyzed` when [post-call analysis](/agents/monitor/post-call-analysis) finishes. Use them to write results into your CRM, ticketing system, or data warehouse without polling the sessions API.
+Point your agent at one or more endpoints on your server and Fish Audio calls them when things happen: `call.ended` the moment a session reaches a terminal state, `call.analyzed` when [post-call analysis](/agents/monitor/post-call-analysis) settles. Use them to write results into your CRM, ticketing system, or data warehouse without polling the sessions API.
 
 ## Events
 
 | Event           | Fires                                                                                            | Payload                                       |
 | --------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
 | `call.ended`    | When a session reaches a terminal state — every real call, whether or not analysis is configured | Session facts plus the reason the call ended  |
-| `call.analyzed` | When post-call analysis completes                                                                | Session facts plus the full `analysis` entity |
+| `call.analyzed` | When post-call analysis settles — completed, skipped, or error                                   | Session facts plus the full `analysis` entity |
 
-For a given session, `call.ended` is always delivered before `call.analyzed`. `call.analyzed` is sent only when analysis actually completes — calls where analysis is skipped (no user speech or analysis disabled) or fails produce `call.ended` only.
+For a given session, `call.ended` is delivered before `call.analyzed`, and every production call produces both events. When analysis has nothing to work with (the caller never spoke, or analysis is disabled) or fails, `call.analyzed` still arrives — with `analysis.status` set to `skipped` or `error` and empty result sections. You never have to infer from silence whether a result is still coming: check `analysis.status`.
 
 <Note>
   Transcripts are deliberately excluded from webhook payloads — fetch them on
@@ -153,6 +153,8 @@ Every payload carries the `event` name and a `session` object with a fixed set o
 
 `end_user_id` and `metadata` are echoed exactly as you set them when creating the session — use them to correlate the event with records in your own system. `branch_id` is an internal configuration-lineage identifier — safe to ignore. What lands in `summary`, `data`, and `criteria_results` is defined by your [analysis configuration](/agents/monitor/post-call-analysis).
 
+The example shows a `completed` analysis. `analysis.status` can also be `skipped` (nothing to analyze — the caller never spoke, or analysis is disabled) or `error` (the run failed, with the cause in `analysis.error`); both arrive with `summary: null` and empty `data` / `criteria_results`. Check the status before reading results.
+
 ## Verify the signature
 
 When an entry has a `secret`, every request to that endpoint carries a signature header with the send time and an HMAC-SHA256 of `{timestamp}.{raw_body}`, keyed with that entry's own secret:
@@ -246,7 +248,7 @@ Endpoints are delivered in parallel and independently: each gets its own attempt
 
 Respond with a `2xx` status within the timeout; a `500` response or a timed-out request counts as a failed attempt. Acknowledge first and process asynchronously — slow handlers burn their own retry budget.
 
-**Idempotency.** At-least-once delivery means the same event can arrive more than once. Each session produces at most one `call.ended` and one `call.analyzed` per endpoint, so dedupe on the pair (`event`, `session.id`) before writing to downstream systems.
+**Idempotency.** At-least-once delivery means the same event can arrive more than once. Retries of one delivery carry an identical body, so dedupe `call.ended` on (`event`, `session.id`) and `call.analyzed` on (`event`, `session.id`, `analysis.finished_at`). The extra element matters because a skipped or failed analysis can be re-run from the console: the recovered result arrives as a fresh `call.analyzed` with a newer `finished_at`, superseding the earlier one.
 
 <Note>
   [Preview calls](/agents/test/preview-calls) made from the Builder never
@@ -292,9 +294,21 @@ app.post(
     const payload = JSON.parse(req.body);
     if (payload.event !== "call.analyzed") return;
 
-    const key = `${payload.event}:${payload.session.id}`;
+    const key = `${payload.session.id}:${payload.analysis.finished_at}`;
     if (seen.has(key)) return; // at-least-once delivery: dedupe
     seen.add(key);
+
+    if (payload.analysis.status !== "completed") {
+      // skipped (the caller never spoke) or error: no verdict to trust.
+      openTicket({
+        subject: `Unjudged call ${payload.session.id}`,
+        body:
+          `Analysis ${payload.analysis.status}` +
+          (payload.analysis.error ? `: ${payload.analysis.error}` : ""),
+        customer: payload.session.end_user_id,
+      });
+      return;
+    }
 
     const verdict = payload.analysis.criteria_results.find(
       c => c.name === "issue_resolved"
@@ -335,17 +349,28 @@ async def fish_webhooks(
     if payload["event"] != "call.analyzed":
         return {}
 
-    key = f"{payload['event']}:{payload['session']['id']}"
+    analysis = payload["analysis"]
+    key = f"{payload['session']['id']}:{analysis['finished_at']}"
     if key in seen:  # at-least-once delivery: dedupe
         return {}
     seen.add(key)
 
-    results = payload["analysis"]["criteria_results"]
+    if analysis["status"] != "completed":
+        # skipped (the caller never spoke) or error: no verdict to trust.
+        detail = f": {analysis['error']}" if analysis.get("error") else ""
+        open_ticket(
+            subject=f"Unjudged call {payload['session']['id']}",
+            body=f"Analysis {analysis['status']}{detail}",
+            customer=payload["session"]["end_user_id"],
+        )
+        return {}
+
+    results = analysis["criteria_results"]
     verdict = next((c for c in results if c["name"] == "issue_resolved"), None)
     if verdict and verdict["result"] != "success":
         open_ticket(
             subject=f"Unresolved call {payload['session']['id']}",
-            body=f"{payload['analysis']['summary']}\n\n"
+            body=f"{analysis['summary']}\n\n"
             f"issue_resolved: {verdict['result']} — {verdict['rationale']}",
             customer=payload["session"]["end_user_id"],
         )
@@ -358,7 +383,7 @@ async def fish_webhooks(
 
 Edges worth handling:
 
-- Calls with nothing to analyze never produce `call.analyzed` (see [Events](#events)). If every call must reach the helpdesk regardless of analysis, watch `call.ended` too.
+- Calls with nothing to analyze arrive with `analysis.status: "skipped"` — the handler above tickets them as unjudged, so every call reaches the helpdesk without also watching `call.ended`. Drop that branch if silent calls don't belong in your queue.
 - Payloads carry no transcript. To include one in the ticket, fetch `GET /v1/agent/sessions/{session_id}` from your handler — see [conversation history](/agents/monitor/conversation-history).
 - Set `end_user_id` and `metadata` when creating sessions so tickets attach to the right customer record without a lookup.
 

--- a/agents/overview.mdx
+++ b/agents/overview.mdx
@@ -24,7 +24,7 @@ Fish Agents is a hosted platform for real-time voice agents. Define an agent's p
 | Surface         | What it does                                                                                            | Start here                                      |
 | --------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
 | **Console**     | Design, test, and publish agents visually — no code.                                                    | [Configuration](/agents/build/configuration)    |
-| **REST API**    | Manage agents, sessions, tools, and knowledge programmatically under `/v1/agent/*`.                     | [Authentication](/agents/deploy/authentication) |
+| **REST API**    | Manage agents, sessions, tools, and knowledge programmatically under `/v1/agent/*`.                     | [API introduction](/api-reference/introduction) |
 | **Client SDKs** | Run live voice conversations in the browser with `@fishaudio/agent-client` or `@fishaudio/agent-react`. | [Web SDK](/agents/deploy/web-sdk)               |
 
 All three operate on the same agents. The core console workflow — creating agents, editing configuration, publishing versions — is also available over the API with your standard Fish Audio API key:

--- a/agents/quickstart.mdx
+++ b/agents/quickstart.mdx
@@ -9,7 +9,7 @@ Build a voice agent and talk to it in a few minutes. Use the console for a no-co
 **Prerequisites**
 
 - A Fish Audio account
-- For the API path: a Fish Audio API key — see [Authentication](/agents/deploy/authentication)
+- For the API path: a Fish Audio API key — create one under [API keys](https://fish.audio/app/api-keys/) in the console
 
 <Tabs>
   <Tab title="Dashboard">
@@ -128,9 +128,8 @@ Build a voice agent and talk to it in a few minutes. Use the console for a no-co
         Start talking — you hear the agent reply and both sides of the conversation arrive as transcript events. See the [Web SDK](/agents/deploy/web-sdk) for the full event and method surface, or the [React SDK](/agents/deploy/react-sdk) for hooks.
       </Step>
       <Step title="Put it together">
-        The whole loop is two files: a backend route that mints the session with your API key, and frontend code that starts the call. Run the server with `FISH_API_KEY` and `AGENT_ID` set, serve the frontend from your app's dev server (Vite, Next — anything that bundles npm imports), and talk.
+        The whole loop is two files: a backend route that creates the session with your API key, and frontend code that starts the call. Run the server with `FISH_API_KEY` and `AGENT_ID` set, serve the frontend from your app's dev server (Vite, Next — anything that bundles npm imports), and talk.
 
-        <CodeGroup>
         ```javascript server.mjs
         import express from "express";
 
@@ -169,7 +168,6 @@ Build a voice agent and talk to it in a few minutes. Use the console for a no-co
           },
         });
         ```
-        </CodeGroup>
 
         Every request and response on this path is in the [Agents API reference](/api-reference/endpoint/agent/create-agent-session).
       </Step>

--- a/agents/telephony/phone-numbers.mdx
+++ b/agents/telephony/phone-numbers.mdx
@@ -60,7 +60,6 @@ A `409` means the number is already on the platform; a `502` means the provider 
 
 Returns your team's phone numbers across its workspaces, newest first — each carries its `workspace_id`.
 
-<CodeGroup>
 ```bash Request
 curl https://api.fish.audio/v1/agent/phone-numbers \
   --header "Authorization: Bearer $FISH_API_KEY"
@@ -81,8 +80,6 @@ curl https://api.fish.audio/v1/agent/phone-numbers \
   "has_more": false
 }
 ```
-
-</CodeGroup>
 
 | Field             | Description                                                      |
 | ----------------- | ---------------------------------------------------------------- |
@@ -168,7 +165,7 @@ curl --request DELETE https://api.fish.audio/v1/agent/phone-numbers/$PHONE_NUMBE
   >
     What happens when someone dials a bound number.
   </Card>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
+  <Card title="API introduction" icon="key" href="/api-reference/introduction">
     API keys and workspace scoping for every request.
   </Card>
   <Card

--- a/api-reference/agent-errors.mdx
+++ b/api-reference/agent-errors.mdx
@@ -92,8 +92,12 @@ Exactly two endpoints charge before acting, and both can return `402 Out of API 
 ## Going further
 
 <CardGroup cols={2}>
-  <Card title="Authentication" icon="key" href="/agents/deploy/authentication">
-    Both auth modes and the session token flow.
+  <Card
+    title="Authenticated sessions"
+    icon="server"
+    href="/agents/deploy/authenticated-sessions"
+  >
+    The session token flow — request fields, lifetime, errors.
   </Card>
   <Card title="Public agents" icon="globe" href="/agents/deploy/public-agents">
     Origin allowlists and the errors unique to keyless access.

--- a/docs.json
+++ b/docs.json
@@ -103,8 +103,8 @@
             "pages": [
               "agents/deploy/overview",
               "agents/deploy/versions-publishing",
-              "agents/deploy/authentication",
               "agents/deploy/public-agents",
+              "agents/deploy/authenticated-sessions",
               "agents/deploy/widget",
               "agents/deploy/web-sdk",
               "agents/deploy/react-sdk",
@@ -401,6 +401,10 @@
     "family": "Onest"
   },
   "redirects": [
+    {
+      "source": "/agents/deploy/authentication",
+      "destination": "/agents/deploy/authenticated-sessions"
+    },
     {
       "source": "/python",
       "destination": "/developer-guide/sdk-guide/python/overview"


### PR DESCRIPTION
## Summary

Retargets the Deploy restructure to `main` (previously landed on the stale `agent-docs` branch as #117 by mistake — main had already absorbed agent-docs via #116). Two commits:

**1. `call.analyzed` webhook semantics sync** — pending doc sync that was stranded on `agent-docs`: the event fires on every terminal analysis status, dedup key includes `finished_at`.

**2. Deploy section restructure.** The old overview presented a four-step "channel ladder" (widget → public → authenticated → phone) conflating two orthogonal axes; clicking **3. Authenticated sessions** landed on a page titled **Authentication** that re-explained both access modes, duplicating the Public agents page.

- **Overview rewritten as two independent decisions**: *where users meet your agent* (widget / your own UI via SDKs / phone / custom client) and *who may start sessions* (public agents vs authenticated sessions, comparison table moved here). States explicitly that every browser surface supports both access modes.
- **`authentication.mdx` → `authenticated-sessions.mdx`** (redirect added in docs.json): now the pure backend session-creation reference — token flow, request fields, response, token lifetime, force-end, errors — plus a client-agnostic table showing where the token goes per surface (Web SDK, React SDK, widget `sessionTokenProvider`, wire protocol).
- **Sidebar reordered** to setup order: overview → versions-publishing → public-agents → authenticated-sessions → widget → web-sdk → react-sdk → protocol.
- **Mislink fixes**: three pages cited the old Authentication page for "API key setup" (never covered there) — now point at `api-reference/introduction` or the console API-keys page; versions-publishing's "Automate via API" card pointed at the Deploy overview, now at the publish endpoint reference.
- **Wording**: "mint/minted/minting" → "create" across agent docs.
- **CodeGroup cleanup**: groups that tabbed *different responsibilities* (backend vs browser, draft-update vs publish, request vs response, distinct API operations) split into sequential blocks; tabs kept only for alternative implementations of the same action.

## Verification

- Both commits cherry-pick cleanly onto main (agents tree on main was identical to the restructure's base; docs.json had no divergence)
- `mint broken-links`: no broken links under `agents/`
- Prettier: all touched files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788590274&installation_model_id=430858&pr_number=118&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F118&signature=3432749f45bde72040d70a09bf8af5b23b5c3b5e495f0d7c45e33db81ab66993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized authentication guidance around authenticated sessions, backend-issued tokens, access modes, and deployment options.
  * Updated documentation links, navigation, and added a redirect from the former authentication page.
  * Clarified webhook behavior for completed, skipped, and failed post-call analysis, including status handling and idempotency guidance.
  * Simplified API examples by removing unnecessary code-group wrappers.
  * Updated API key and publishing links to point directly to the relevant resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->