### PR TITLE
Remove Language detection; drop Transfer call from the system tools table

### DIFF
--- a/agents/build/configuration.mdx
+++ b/agents/build/configuration.mdx
@@ -32,7 +32,7 @@ Choose how the agent opens each conversation:
 
 ## Voice
 
-The Voice panel selects the voice your agent speaks with (`voice_id`) and its speaking language (`speaking_language`: `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`). See [Voice & language](/agents/build/voice-language) for picking a voice and how automatic language detection interacts with this setting.
+The Voice panel selects the voice your agent speaks with (`voice_id`) and its speaking language (`speaking_language`: `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`). See [Voice & language](/agents/build/voice-language) for picking a voice.
 
 ## Conversation settings
 

--- a/agents/build/system-tools.mdx
+++ b/agents/build/system-tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: "System Tools"
-description: "Built-in agent capabilities — language detection, hang up call, and call transfer — enabled per agent"
+description: "Built-in agent capabilities like hanging up the call, enabled per agent"
 icon: "toggle-on"
 ---
 
@@ -8,9 +8,7 @@ System tools are capabilities built into the platform. There is nothing to creat
 
 | Tool | Key | What it does |
 |---|---|---|
-| Language detection | `language_detection` | Lets the agent detect the language the user is speaking. |
 | Hang up call | `hang_up_call` | Lets the agent end the call itself. |
-| Transfer call | `transfer_call` | Lets the agent hand a live phone call to another number. |
 
 <Note>
 Unlike [webhook tools](/agents/build/webhook-tools), system tools are not workspace resources shared across agents. The on/off state is stored per agent — toggling a system tool on one agent never affects another.
@@ -18,7 +16,7 @@ Unlike [webhook tools](/agents/build/webhook-tools), system tools are not worksp
 
 ## Toggle in the Builder
 
-Open your agent's **Tools** page in the Builder. The **System tools** card holds the **Hang up call** switch. The **Language detection** switch lives on the agent's **Configuration** page, next to **Speaking language** — see [Voice & language](/agents/build/voice-language). Flip a switch to enable or disable that capability for this agent.
+Open your agent's **Tools** page in the Builder. The **System tools** card holds the **Hang up call** switch — flip it to enable or disable that capability for this agent.
 
 ## Toggle via the API
 

--- a/agents/build/tools.mdx
+++ b/agents/build/tools.mdx
@@ -24,7 +24,7 @@ Out of the box, an agent can only talk. Tools let it act: fetch an order status 
 |---|---|---|
 | [Webhook](/agents/build/webhook-tools) | Fish Audio — we call your HTTP endpoint during the conversation | Order lookups, CRM reads, bookings — anything your backend can answer |
 | [Client](/agents/build/client-tools) | Your app — the SDK hands the call to code you register | Navigation, UI updates, device actions — anything only the client can do |
-| [System](/agents/build/system-tools) | The platform — no code involved | Language detection, hanging up the call |
+| [System](/agents/build/system-tools) | The platform — no code involved | Hanging up the call |
 
 Webhook and client tools are **custom tools**: you define a name, a description, and arguments, and the agent fills in the argument values when it calls. System tools are ready-made — enable them with a switch on each agent.
 

--- a/agents/build/voice-language.mdx
+++ b/agents/build/voice-language.mdx
@@ -65,16 +65,7 @@ curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
 
 ## Speaking language
 
-**Speaking language** sets the default language for the agent's conversations — one of `en`, `ja`, `zh`, `ko`, `es`, `fr`, or `de` (`voice.speaking_language` on the wire). Whether it is pinned or just a fallback depends on the **Language detection** [system tool](/agents/build/system-tools):
-
-| Language detection | Session behavior |
-|---|---|
-| On | The session runs in automatic language mode — the agent follows the language the caller actually speaks. |
-| Off (default) | Every session uses the configured speaking language. |
-
-<Tip>
-  If your agent must always converse in one specific language, leave Language detection off — the session then sticks to `speaking_language` regardless of what it hears.
-</Tip>
+**Speaking language** sets the language for the agent's conversations — one of `en`, `ja`, `zh`, `ko`, `es`, `fr`, or `de` (`voice.speaking_language` on the wire). Every session converses in this language.
 
 <Note>
   The voice model and the speaking language are independent settings: picking a voice does not change the language, and vice versa. Choose a voice that sounds natural in the language you configure.
@@ -89,7 +80,7 @@ Both settings can also be replaced for a single session — send `overrides.voic
     System prompt, first message, and conversation settings.
   </Card>
   <Card title="System tools" icon="wrench" href="/agents/build/system-tools">
-    Language detection and other built-in capabilities.
+    Built-in capabilities like hanging up the call.
   </Card>
   <Card title="Preview calls" icon="phone" href="/agents/test/preview-calls">
     Talk to your draft agent and hear the voice live.

--- a/agents/deploy/authenticated-sessions.mdx
+++ b/agents/deploy/authenticated-sessions.mdx
@@ -141,7 +141,7 @@ Unknown fields — top-level or inside `overrides` — are rejected with `422`.
 | `first_message_prompt` | string, up to 10,000 characters          | Instructions the agent generates its opener from, replacing the configured first-message behavior. `{{placeholders}}` render inside it. Mutually exclusive with `first_message` — sending both is `422`.          |
 | `system_prompt`        | string, up to 8,000 characters           | Replaces the configured system prompt entirely. `{{placeholders}}` render inside it.                                                                                                                              |
 | `voice_id`             | string                                   | The voice the agent speaks with — any [voice model id](/agents/build/voice-language#use-any-voice-model) from the Voice Library. Voices bias pronunciation toward their own language, so pair it with `language`. |
-| `language`             | `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de` | Pins the conversation language, taking precedence over the configured [speaking language](/agents/build/voice-language#speaking-language) and automatic language detection.                                       |
+| `language`             | `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de` | Pins the conversation language, taking precedence over the configured [speaking language](/agents/build/voice-language#speaking-language).                                       |
 
 ```json
 {

--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -671,7 +671,7 @@
       },
       "post": {
         "summary": "Create Agent Session",
-        "description": "Start a conversation session with an agent and receive a join token for the\nsession transport (currently LiveKit WebRTC). Authenticate with an API key to\nstart sessions with any agent in your team; without credentials only agents\npublished as public are reachable, and the request `Origin` must match the\nagent's allowed origins.\n\n`language` (and `overrides.language`) accepts `en`, `ja`, `zh`, `ko`, `es`,\n`fr`, `de`; anything else is 422. Omit it to use the agent's configured\nbehavior (including automatic language detection when enabled).",
+        "description": "Start a conversation session with an agent and receive a join token for the\nsession transport (currently LiveKit WebRTC). Authenticate with an API key to\nstart sessions with any agent in your team; without credentials only agents\npublished as public are reachable, and the request `Origin` must match the\nagent's allowed origins.\n\n`language` (and `overrides.language`) accepts `en`, `ja`, `zh`, `ko`, `es`,\n`fr`, `de`; anything else is 422. Omit it to use the agent's configured\nspeaking language.",
         "security": [
           {
             "BearerAuth": []
@@ -11704,18 +11704,6 @@
       "PublicSystemToolsPatch": {
         "additionalProperties": false,
         "properties": {
-          "language_detection": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "title": "Language Detection"
-          },
           "hang_up_call": {
             "anyOf": [
               {
@@ -12058,11 +12046,6 @@
       },
       "AgentSystemToolsConfig": {
         "properties": {
-          "language_detection": {
-            "default": false,
-            "title": "Language Detection",
-            "type": "boolean"
-          },
           "hang_up_call": {
             "default": false,
             "title": "Hang Up Call",

--- a/llms.txt
+++ b/llms.txt
@@ -65,7 +65,7 @@
 - [Tools Overview](https://docs.fish.audio/agents/build/tools.md): Webhook, client, and system tools for voice agents.
 - [Webhook Tools](https://docs.fish.audio/agents/build/webhook-tools.md): Let the agent call your HTTP endpoints, with templating and testing.
 - [Client Tools](https://docs.fish.audio/agents/build/client-tools.md): Tools your app executes in the browser through the SDK.
-- [System Tools](https://docs.fish.audio/agents/build/system-tools.md): Built-in language detection and hang-up capabilities.
+- [System Tools](https://docs.fish.audio/agents/build/system-tools.md): Built-in capabilities like hanging up the call.
 - [Dynamic Variables & Overrides](https://docs.fish.audio/agents/build/dynamic-variables.md): Personalize each session with variables and whitelisted overrides.
 - [Versions & Publishing](https://docs.fish.audio/agents/deploy/versions-publishing.md): Draft, publish, clone, and restore agent configurations.
 - [Deployment Overview](https://docs.fish.audio/agents/deploy/overview.md): Pick a deployment channel — widget, public agents, authenticated sessions, or a phone number.


### PR DESCRIPTION
Companion to fishaudio/platform-api#1266 (removes the `language_detection` system tool from the product).

- `system-tools.mdx`: table now lists only Hang up call; Transfer call leaves the toggle table (it has no switch — auto-enabled once a transfer destination is configured; its explanatory section stays). Builder section no longer points at a Configuration-page switch.
- `voice-language.mdx`: speaking language is now unconditional — detection table and Tip removed.
- `tools.mdx` / `configuration.mdx` / `authenticated-sessions.mdx` / `llms.txt`: passing mentions cleaned up.
- `openapi.json`: `language_detection` removed from `AgentSystemToolsConfig` / `PublicSystemToolsPatch`; session-creation description updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788602169&installation_model_id=430858&pr_number=121&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F121&signature=d4f044a1029be0a576998746b8e7d8f78dd4369e85f6e7fc1de9c653f54c6f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that sessions use the configured speaking language by default.
  * Updated language override guidance to reflect current behavior.
  * Removed references to automatic language detection from voice and system tool documentation.
  * Updated system tool documentation to describe call hang-up functionality only.
  * Removed the language detection option from the API schema and session documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->