### PR TITLE
docs: private-beta 403 message points at the web application form

### DIFF
--- a/api-reference/agent-errors.mdx
+++ b/api-reference/agent-errors.mdx
@@ -55,14 +55,14 @@ Two quirks worth coding around:
 
 ## 403: what was refused
 
-| Message                                          | Cause                                                                                                       |
-| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| `Agent is not public`                            | Anonymous session/widget request against an agent whose public switch is off.                               |
-| `Origin header is required for public agents`    | Anonymous request without an `Origin` header — browsers send it automatically, curl must set it.            |
-| `Origin not allowed`                             | The page's origin is not on the agent's [allowed origins](/agents/deploy/public-agents#origin-matching).    |
-| `Agent is unavailable`                           | The agent's owner can't serve public sessions right now; visitors deliberately can't tell why.              |
-| `Agent platform is not enabled for this account` | Creating agent resources requires Agents access on your account — contact support if you expect to have it. |
-| `Phone number limit reached for this team (N)`   | The team holds its maximum of live numbers; release one first.                                              |
+| Message                                                                                | Cause                                                                                                                 |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `Agent is not public`                                                                  | Anonymous session/widget request against an agent whose public switch is off.                                         |
+| `Origin header is required for public agents`                                          | Anonymous request without an `Origin` header — browsers send it automatically, curl must set it.                      |
+| `Origin not allowed`                                                                   | The page's origin is not on the agent's [allowed origins](/agents/deploy/public-agents#origin-matching).              |
+| `Agent is unavailable`                                                                 | The agent's owner can't serve public sessions right now; visitors deliberately can't tell why.                        |
+| `Agent platform is in private beta. Apply for access at https://fish.audio/app/agents` | Creating agent resources requires beta access on your account — sign in and submit the application form at that link. |
+| `Phone number limit reached for this team (N)`                                         | The team holds its maximum of live numbers; release one first.                                                        |
 
 ## 404: anti-enumeration
 


### PR DESCRIPTION
## Summary
Sync the 403 table with platform-api (fishaudio/platform-api#1267): the rollout refusal message is now `Agent platform is in private beta. Apply for access at https://fish.audio/app/agents`, and the cause cell tells readers to sign in and submit the application form there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788620299&installation_model_id=430858&pr_number=123&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F123&signature=9445eadf90dd5013ae3a40dc5f3a1364b7459016eda1dc5580acf93c5c197b69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `403` error guidance to explain that agent platform access is currently limited to a private beta.
  * Added instructions for applying for access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->