### PR TITLE
Add enterprise appliance and release-history pages

### DIFF
--- a/developer-guide/self-hosting/enterprise-appliance.mdx
+++ b/developer-guide/self-hosting/enterprise-appliance.mdx
@@ -1,0 +1,122 @@
+---
+title: "Enterprise Appliance"
+description: "Run the Fish Audio TTS stack on your own hardware from a single container"
+icon: "server"
+---
+
+The enterprise appliance is the whole Fish Audio TTS stack — model weights included — in one
+container. It needs no Kubernetes and no network access at runtime, which makes it suitable for
+on-prem, single-tenant, and air-gapped deployments.
+
+<Note>
+  The appliance is part of an enterprise agreement. Your team needs the **Self
+  Host** feature and a grant for the All-in-One artifact before the commands
+  below will work. If Developer → Self Host does not appear in your dashboard,
+  contact your account manager.
+</Note>
+
+## What you get
+
+|                    |                                                                                                                                                          |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Exposed port       | `8088` — the TTS API. Nothing else is published.                                                                                                         |
+| GPUs               | **2**, validated on 2× RTX 5090 (32 GB) and 2× H100 80 GB. GPU 0 runs the language model, GPU 1 runs the vocoder. No NVLink required.                    |
+| Scaling            | one inference worker on two GPUs. It does not shard across more GPUs or nodes — for elastic or multi-tenant throughput, use the Helm deployment instead. |
+| Network at runtime | none. Weights are baked into the image.                                                                                                                  |
+
+## 1. Prerequisites
+
+- Docker with the **NVIDIA Container Toolkit** installed and the `nvidia` runtime registered.
+  Verify with `docker run --rm --gpus all <cuda-image> nvidia-smi`.
+- Enough disk for the image: roughly **28 GB compressed, 60 GB unpacked**.
+- A **deploy token**, created in Developer → Self Host. That page also shows the version to run.
+
+## 2. Sign in and pull
+
+Your username is your Fish Audio account email; the password is a deploy token.
+
+```bash
+echo '<your-deploy-token>' | docker login registry.fish.audio -u '<your-email>' --password-stdin
+docker pull registry.fish.audio/self-hosted/enterprise/all-in-one:<version>
+```
+
+<Tip>
+  Developer → Self Host renders both of these commands with your email and the
+  current version already filled in. Copy them from there rather than typing the
+  version by hand.
+</Tip>
+
+For an air-gapped host, pull on a machine that can reach the registry, then move the image:
+
+```bash
+docker save registry.fish.audio/self-hosted/enterprise/all-in-one:<version> \
+  | zstd -T0 -3 -o all-in-one.tar.zst
+# on the target host:
+zstd -d -c all-in-one.tar.zst | docker load
+```
+
+## 3. Run
+
+Generate a JWT secret **once**, store it, and reuse the same value on every run.
+
+```bash
+export FISH_JWT_SECRET="$(openssl rand -hex 32)"
+
+docker run -d --name fish-tts \
+  --gpus all \
+  --shm-size 16g --ulimit memlock=-1 --ulimit stack=67108864 \
+  -p 8088:8088 \
+  -v fish-tts-shared:/mnt/shared \
+  -e JWT_SECRET="$FISH_JWT_SECRET" \
+  --restart unless-stopped \
+  registry.fish.audio/self-hosted/enterprise/all-in-one:<version>
+```
+
+<Warning>
+  `JWT_SECRET` is required for any production deployment. Without it the
+  container falls back to a fixed built-in development default, which is not
+  secret. Changing the value later invalidates every token and session issued
+  under the old one.
+</Warning>
+
+**`--gpus all`** pins the worker to GPU 0 and the vocoder to GPU 1. On a host with more than two
+GPUs it takes the first two; to choose specific cards use `--gpus '"device=0,1"'`.
+
+**`-v fish-tts-shared:/mnt/shared`** is one persistent volume for everything that must survive a
+restart: the compile and CUDA-graph caches, the vocoder engine, reference voices, and the usage
+ledger. It is what makes restarts fast.
+
+<Note>
+  The **first start compiles for around 10 minutes** once the image is on the
+  host. A completely cold host that also has to transfer the ~28 GB image can
+  take 45–75 minutes end to end, depending on the network. Later starts on the
+  same volume take minutes. Keep the volume.
+</Note>
+
+The container runs fully non-root — PID 1 and every service as UID 1000. A fresh named volume
+inherits that ownership and works as-is; an existing volume or a host bind-mount must be writable
+by UID 1000.
+
+## 4. Check it is serving
+
+```bash
+curl -fsS http://localhost:8088/health
+```
+
+## Upgrading
+
+Developer → Self Host shows the version your team recorded and tells you when a newer one is
+available, with a link to what changed. Upgrading is: pull the new tag, stop the old container,
+start a new one with the same volume and the same `JWT_SECRET`.
+
+```bash
+docker pull registry.fish.audio/self-hosted/enterprise/all-in-one:<new-version>
+docker stop fish-tts && docker rm fish-tts
+# re-run the command from step 3 with the new tag
+```
+
+The volume is reused deliberately: the caches in it are keyed by content, so a new image rebuilds
+only what actually changed. Keep the old image on the host until the new one has served traffic —
+rolling back is then just starting the previous tag again.
+
+See [Appliance Releases](/developer-guide/self-hosting/enterprise-releases) for the version list.

--- a/developer-guide/self-hosting/enterprise-releases.mdx
+++ b/developer-guide/self-hosting/enterprise-releases.mdx
@@ -1,0 +1,49 @@
+---
+title: "Appliance Releases"
+description: "Version history for the Fish Audio enterprise appliance"
+icon: "tag"
+---
+
+Every version of the [enterprise appliance](/developer-guide/self-hosting/enterprise-appliance)
+we have released, newest first. Developer → Self Host shows which one your team recorded as
+running and links here when a newer one is available.
+
+<Note>
+  Versions are immutable. A tag always refers to the same image — we never
+  re-point one at different content, so a deployment pinned to a tag keeps
+  getting the bytes it was tested with. Fixes ship as a new version.
+</Note>
+
+## How to read a version
+
+```
+s2.1-pro-20260803-offline
+└──┬───┘ └──┬───┘ └──┬──┘
+   │        │        └─ variant: `offline` records usage to a local signed ledger
+   │        └─ the date we published it
+   └─ the model generation it serves
+```
+
+---
+
+## s2.1-pro-20260803-offline
+
+<Update label="2026-08-03" tags={["current"]}>
+First generally available build of the appliance.
+
+- Serves the S2.1 Pro voice model, weights baked in — no network access at runtime.
+- Two GPUs: language model on GPU 0, vocoder on GPU 1.
+- Usage recorded to a local signed ledger; nothing is reported off the host.
+- Runs fully non-root (UID 1000).
+
+**Upgrading:** nothing to migrate — this is the first release.
+
+</Update>
+
+---
+
+## Getting an older version
+
+The dashboard lists the versions we currently recommend. If you need one that is no longer
+listed — to reproduce a node exactly as it was, for instance — contact your account manager
+rather than guessing a tag.

--- a/docs.json
+++ b/docs.json
@@ -203,7 +203,9 @@
             "pages": [
               "developer-guide/self-hosting/local-setup",
               "developer-guide/self-hosting/docker-deployment",
-              "developer-guide/self-hosting/running-inference"
+              "developer-guide/self-hosting/running-inference",
+              "developer-guide/self-hosting/enterprise-appliance",
+              "developer-guide/self-hosting/enterprise-releases"
             ]
           },
           {


### PR DESCRIPTION
Enterprise self-host customers have had nowhere public to read how to run the appliance or what changed between versions — the existing Self-Hosting section covers the open-source `fish-speech` images, a different product for a different audience.

This is the docs half of FISH-772. The dashboard change (fishaudio/platform-web#2162) shows customers the version they should run and links to release notes when a newer one exists; **those links need a page to point at**, which is what `enterprise-releases` is.

## Two pages

**Enterprise Appliance** — prerequisites, sign in and pull (including the air-gapped `docker save` / `docker load` path), the run command with the reasoning behind the flags that actually matter (`JWT_SECRET`, the shared volume, GPU pinning), the first-start compile time, and how to upgrade and roll back.

**Appliance Releases** — the version list, with an explanation of how to read a tag. One entry today.

Content is taken from the operator guide we have been sending customers by hand, trimmed to what a customer needs: no registry internals, no build pipeline.

## Two things I deliberately did not write

Both are commitments only the business can make, and I would rather leave a gap than publish a promise we have not agreed to:

- **A support window.** How long does an old version keep getting fixes?
- **Whether older tags stay pullable indefinitely.** The page currently points people at their account manager instead.

## Known gaps

- The version list has a single entry; it needs a real second one the first time we ship an upgrade.
- "How to read a version" assumes the current naming scheme holds.
- Numbers (GPU models, VRAM, image size, compile time) come from our own validation runs and should be sanity-checked by whoever last measured them.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788624785&installation_model_id=430858&pr_number=124&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F124&signature=717927c8f38a45b92a95d4869d5735e8a8746931f7e68a6e92487a525da77bda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for deploying the Enterprise Appliance, including prerequisites, configuration, storage, health checks, and upgrades.
  - Added enterprise release history and versioning information, including offline deployment details and rollback guidance.
  - Updated self-hosting navigation to include the new Enterprise Appliance and Enterprise Releases pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->