### PR TITLE
docs(protocol): re-baseline version pins to the public npm line

### DIFF
--- a/agents/deploy/protocol.mdx
+++ b/agents/deploy/protocol.mdx
@@ -15,7 +15,7 @@ Everything the SDKs do rides a small, versioned wire protocol: two JSON message 
 
 ## The protocol package
 
-Every message shape on this page is published as TypeScript definitions in `@fishaudio/agent-protocol` — zero runtime dependencies. This page documents protocol revision **0.3.0**; the npm package is versioned independently. The package is the source of truth for shapes; this page fixes the semantics.
+Every message shape on this page is published as TypeScript definitions in `@fishaudio/agent-protocol` — zero runtime dependencies. This page documents the protocol as of package version **0.1.0**. The package is the source of truth for shapes; this page fixes the semantics.
 
 ```bash npm
 npm install @fishaudio/agent-protocol
@@ -130,7 +130,7 @@ Publish these on the `client-event` topic. The agent ignores malformed JSON and 
 }
 ```
 
-- `user.message` gets **no server echo** — you already hold the text, so render the bubble locally. Add `"audio": false` (protocol 0.3.0) to have the agent answer that turn in text only: no speech is synthesized and the reply arrives over transcription.
+- `user.message` gets **no server echo** — you already hold the text, so render the bubble locally. Add `"audio": false` to have the agent answer that turn in text only: no speech is synthesized and the reply arrives over transcription.
 - `client_tool.result` may carry `result` (any JSON value) or `"isError": true` to report the tool as failed to the model. Results for unknown or already-settled `callId`s are ignored.
 
 ## Transcription and agent state
@@ -150,12 +150,12 @@ These ride the transport's built-in mechanisms rather than custom messages.
 2. **Evolution is additive-only.** Published fields never change name or meaning and are never removed; new fields are always optional. A semantic change ships as a new `type`.
 3. **No replay.** Data-channel delivery is reliable and ordered within a connection, but after a reconnect or late join, missed messages are gone — never wait for history. Tool terminal messages repeat their identifying fields, and the state attribute is sticky, precisely to soften this.
 
-## Protocol revision history
+## Version history
 
-| Revision        | Changes                                                                                                              |
-| --------------- | -------------------------------------------------------------------------------------------------------------------- |
-| 0.2.0           | Added tool lifecycle events (`tool.started` / `tool.completed` / `tool.failed`) and the `tool_events` session option |
-| 0.3.0 (current) | Added the optional `audio` flag on `user.message` for per-turn text-only replies                                     |
+| Version         | Changes                                                                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.0.1           | Initial public release — the complete message set on this page, including tool lifecycle events and the optional `audio` flag on `user.message`    |
+| 0.1.0 (current) | Revised the session-creation `SessionOverrides` shape; realtime messages unchanged                                                                 |
 
 ## Going further
 


### PR DESCRIPTION
The protocol page still referenced internal pre-release revision 0.3.0, which was voided at release. Pin the page to `@fishaudio/agent-protocol` 0.1.0 and list the public versions (0.0.1, 0.1.0) in the history table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788877850&installation_model_id=430858&pr_number=127&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F127&signature=1f6cff128b7cf8ebcd7980e81eb4ad10de2414b1340c8f32da1f7d64dfd85463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented protocol package version to 0.1.0.
  * Clarified the `audio` flag description.
  * Replaced protocol revision history with package version history for versions 0.0.1 and 0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->