### PR TITLE
docs(quickstart): correct SDK install trap and model defaults

### DIFF
--- a/.mintlify/skills/fish-audio-sdk/references/installation.md
+++ b/.mintlify/skills/fish-audio-sdk/references/installation.md
@@ -9,6 +9,9 @@ pip install "fish-audio-sdk[utils]" # adds local audio playback helpers (play)
 
 - Requires Python 3.9+.
 - Import name is **`fishaudio`** even though the PyPI/dist name is `fish-audio-sdk`.
+- Never `pip install fishaudio` — that PyPI name is an unrelated third-party
+  project. It installs cleanly, then fails with `ImportError: cannot import name
+  'FishAudio' from 'fishaudio'`.
 
 ## JavaScript / TypeScript (`fish-audio`)
 

--- a/developer-guide/getting-started/quickstart.mdx
+++ b/developer-guide/getting-started/quickstart.mdx
@@ -44,13 +44,20 @@ Choose your preferred method to generate speech:
         curl -X POST https://api.fish.audio/v1/tts \
           -H "Authorization: Bearer $FISH_API_KEY" \
           -H "Content-Type: application/json" \
-          -H "model: s2-pro" \
+          -H "model: s2.1-pro" \
           -d '{
             "text": "Hello! Welcome to Fish Audio. This is my first AI-generated voice.",
             "format": "mp3"
           }' \
           --output welcome.mp3
         ```
+
+        <Note>
+          `s2.1-pro` is the current recommended model. To generate at $0 while you
+          evaluate, send `model: s2.1-pro-free` instead — see [Choosing a
+          Model](/developer-guide/models-pricing/choosing-a-model). Both require a
+          funded API balance; see [If your first request fails](#if-your-first-request-fails).
+        </Note>
       </Step>
 
       <Step title="Play your audio">
@@ -80,6 +87,21 @@ Choose your preferred method to generate speech:
         pip install fish-audio-sdk
         ```
 
+        <Warning>
+          The package name and the import name differ: you install
+          `fish-audio-sdk` but you import `fishaudio`.
+
+          Do not run `pip install fishaudio`. That name belongs to an unrelated
+          third-party project on PyPI, and it installs successfully — the failure
+          only shows up on the next line:
+
+          ```
+          ImportError: cannot import name 'FishAudio' from 'fishaudio'
+          ```
+
+          If you hit that error, run `pip uninstall fishaudio` and then
+          `pip install fish-audio-sdk`.
+        </Warning>
       </Step>
 
       <Step title="Generate speech">
@@ -93,11 +115,20 @@ Choose your preferred method to generate speech:
         client = FishAudio()  # reads FISH_API_KEY
 
         # Generate speech
-        audio = client.tts.convert(text="Hello! Welcome to Fish Audio.")
+        audio = client.tts.convert(
+            text="Hello! Welcome to Fish Audio.",
+            model="s2.1-pro",
+        )
         save(audio, "welcome.mp3")
 
-        print("✓ Audio saved to welcome.mp3")
+        print("Audio saved to welcome.mp3")
         ```
+
+        <Note>
+          Pass `model` explicitly. The published SDK still defaults to `s2-pro`,
+          so requests that omit it run on the previous-generation model. Use
+          `model="s2.1-pro-free"` to generate at $0 while you evaluate.
+        </Note>
       </Step>
 
       <Step title="Run the script">
@@ -151,8 +182,16 @@ Choose your preferred method to generate speech:
         const buffer = Buffer.from(await new Response(audio).arrayBuffer());
         await writeFile("welcome.mp3", buffer);
 
-        console.log("✓ Audio saved to welcome.mp3");
+        console.log("Audio saved to welcome.mp3");
         ```
+
+        <Note>
+          The JavaScript SDK is in early release and currently targets `s2-pro`;
+          its `Backends` type does not yet include the S2.1 models. To use
+          `s2.1-pro` or `s2.1-pro-free` today, call the [HTTP
+          API](/api-reference/endpoint/openapi-v1/text-to-speech) with the `model`
+          header, or use the Python SDK.
+        </Note>
       </Step>
 
       <Step title="Run the script">
@@ -187,9 +226,18 @@ Choose your preferred method to generate speech:
 | Status | Likely cause | Fix |
 |---|---|---|
 | `401` | Invalid or missing API key | Check `FISH_API_KEY` and your key on [API Keys](https://fish.audio/app/api-keys). |
-| `402` | Out of credits | Top up on [Billing](https://fish.audio/app/billing). |
+| `402` | No API balance | Top up on [Billing](https://fish.audio/app/billing). Applies to `s2.1-pro-free` too — see below. |
 | `400` | Bad `reference_id` / parameters | Verify the voice id; read the error `message`. |
 | `429` | Rate limit | Wait and retry with backoff. |
+
+<Warning>
+  **`402` on `s2.1-pro-free`:** the free model is billed at $0.00, but the API
+  still requires a positive balance on your API wallet before it will serve any
+  request. A new account starts at zero, and the credits included with the free
+  plan apply to the web app rather than to the API. Add credits on
+  [Billing](https://fish.audio/app/billing) once and `s2.1-pro-free` requests
+  will go through without drawing that balance down.
+</Warning>
 
 See [Errors](/api-reference/errors) for the full table and retry handling.
 
@@ -225,7 +273,7 @@ Then generate speech with your chosen voice:
     curl -X POST https://api.fish.audio/v1/tts \
       -H "Authorization: Bearer $FISH_API_KEY" \
       -H "Content-Type: application/json" \
-      -H "model: s2-pro" \
+      -H "model: s2.1-pro" \
       -d '{
         "text": "This is a custom voice from Fish Audio! You can explore hundreds of different voices on the platform, or even create your own.",
         "reference_id": "'"$REFERENCE_ID"'",
@@ -246,7 +294,8 @@ Then generate speech with your chosen voice:
     # Generate speech with custom voice
     audio = client.tts.convert(
         text="This is a custom voice from Fish Audio! You can explore hundreds of different voices on the platform, or even create your own.",
-        reference_id=os.environ.get("REFERENCE_ID")
+        reference_id=os.environ.get("REFERENCE_ID"),
+        model="s2.1-pro",
     )
     save(audio, "custom_voice.mp3")
     ```
@@ -267,7 +316,7 @@ Then generate speech with your chosen voice:
     const buffer = Buffer.from(await new Response(audio).arrayBuffer());
     await writeFile("custom_voice.mp3", buffer);
 
-    console.log("✓ Audio saved to custom_voice.mp3");
+    console.log("Audio saved to custom_voice.mp3");
     ```
   </Tab>
 </Tabs>

--- a/developer-guide/getting-started/quickstart.mdx
+++ b/developer-guide/getting-started/quickstart.mdx
@@ -53,10 +53,9 @@ Choose your preferred method to generate speech:
         ```
 
         <Note>
-          `s2.1-pro` is the current recommended model. To generate at $0 while you
-          evaluate, send `model: s2.1-pro-free` instead — see [Choosing a
-          Model](/developer-guide/models-pricing/choosing-a-model). Both require a
-          funded API balance; see [If your first request fails](#if-your-first-request-fails).
+          `s2.1-pro` is the current recommended model and is billed per byte. To
+          generate at $0 while you evaluate, send `model: s2.1-pro-free` instead —
+          see [Choosing a Model](/developer-guide/models-pricing/choosing-a-model).
         </Note>
       </Step>
 
@@ -226,18 +225,15 @@ Choose your preferred method to generate speech:
 | Status | Likely cause | Fix |
 |---|---|---|
 | `401` | Invalid or missing API key | Check `FISH_API_KEY` and your key on [API Keys](https://fish.audio/app/api-keys). |
-| `402` | No API balance | Top up on [Billing](https://fish.audio/app/billing). Applies to `s2.1-pro-free` too — see below. |
+| `402` | Out of credits | Top up on [Billing](https://fish.audio/app/billing), or switch to `s2.1-pro-free`. |
 | `400` | Bad `reference_id` / parameters | Verify the voice id; read the error `message`. |
 | `429` | Rate limit | Wait and retry with backoff. |
 
-<Warning>
-  **`402` on `s2.1-pro-free`:** the free model is billed at $0.00, but the API
-  still requires a positive balance on your API wallet before it will serve any
-  request. A new account starts at zero, and the credits included with the free
-  plan apply to the web app rather than to the API. Add credits on
-  [Billing](https://fish.audio/app/billing) once and `s2.1-pro-free` requests
-  will go through without drawing that balance down.
-</Warning>
+<Tip>
+  A `402` on your very first request usually means you sent a paid model
+  (`s2.1-pro`, `s2-pro`, or `s1`) from an account with no API balance. Send
+  `model: s2.1-pro-free` to generate at $0 while you evaluate.
+</Tip>
 
 See [Errors](/api-reference/errors) for the full table and retry handling.
 

--- a/developer-guide/sdk-guide/quickstart.mdx
+++ b/developer-guide/sdk-guide/quickstart.mdx
@@ -30,6 +30,20 @@ npm install fish-audio
 ```
 </CodeGroup>
 
+<Warning>
+  In Python you install `fish-audio-sdk` but import `fishaudio`. `pip install
+  fishaudio` pulls an unrelated third-party project from PyPI that installs
+  cleanly and then fails with `ImportError: cannot import name 'FishAudio' from
+  'fishaudio'`.
+</Warning>
+
+<Note>
+  Existing integrations may still import `fish_audio_sdk`. That legacy namespace
+  ships in the same distribution and continues to work, but new code should use
+  `fishaudio` — see the [migration
+  guide](/archive/python-sdk-legacy/migration-guide).
+</Note>
+
 ## 2. Authenticate
 
 <Prerequisites />
@@ -49,7 +63,7 @@ from fishaudio.utils import save
 
 client = FishAudio()  # reads FISH_API_KEY
 
-audio = client.tts.convert(text="Hello from Fish Audio!")
+audio = client.tts.convert(text="Hello from Fish Audio!", model="s2.1-pro")
 save(audio, "output.mp3")
 ```
 
@@ -63,6 +77,13 @@ await play(audio);
 </CodeGroup>
 
 Run it, and you'll have `output.mp3` (Python) or local playback (JavaScript). That's it — you're generating speech.
+
+<Note>
+  Always pass `model` explicitly in Python. The published SDK defaults to
+  `s2-pro`, so calls that omit it run on the previous-generation model. The
+  JavaScript SDK targets `s2-pro` and cannot yet select the S2.1 models. See
+  [Choosing a Model](/developer-guide/models-pricing/choosing-a-model).
+</Note>
 
 <Tip>
   Want async in Python? Every method mirrors onto `AsyncFishAudio`: `async with

--- a/features/text-to-speech.mdx
+++ b/features/text-to-speech.mdx
@@ -65,7 +65,7 @@ import { writeFile } from "fs/promises";
 
 const client = new FishAudioClient({ apiKey: process.env.FISH_API_KEY });
 
-// `s2-pro` is passed explicitly (the SDK default is `s1`).
+// `s2-pro` is passed explicitly; it is also the SDK default.
 const stream = await client.textToSpeech.convert(
   { text: "Hello from Fish Audio!" },
   "s2-pro",
@@ -112,7 +112,14 @@ curl --request POST https://api.fish.audio/v1/tts \
 - **`s2-pro`** — previous-generation S2 model with multi-speaker and natural-language expression control.
 - **`s1`** — previous generation, `(parenthesis)` emotion tags.
 
-In the API, select with the `model` request header; requests without it use `s2.1-pro`. The Python SDK always sends a model and defaults to `model="s2-pro"`. See [Choosing a Model](/developer-guide/models-pricing/choosing-a-model).
+In the API, select with the `model` request header; requests without it use `s2.1-pro`.
+
+The SDKs behave differently from the raw API here, so set the model explicitly:
+
+- **Python** always sends a model header and defaults to `model="s2-pro"`. Pass `model="s2.1-pro"` (or `"s2.1-pro-free"`) to get the current generation. Any model string is accepted at runtime; the released type hints still list only the S1/S2 names, so a type checker may flag the S2.1 values.
+- **JavaScript** defaults to `s2-pro`, and its `Backends` type does not yet include the S2.1 models.
+
+See [Choosing a Model](/developer-guide/models-pricing/choosing-a-model).
 
 ### Output formats
 


### PR DESCRIPTION
Follow-up to the Sakana onboarding friction and Richard Sproat's `ImportError`.

## What was broken

**1. The `pip install fishaudio` trap** (caused Richard's error)

The distribution is `fish-audio-sdk`; only the *import* is `fishaudio`. `fishaudio` is also a real, unrelated third-party project on PyPI (v0.0.5, empty `__init__.py`). It installs cleanly, so the failure surfaces one line later:

```
ImportError: cannot import name 'FishAudio' from 'fishaudio'
```

Reproduced in a clean venv — this is exactly the error Richard reported.

**2. The quickstarts pointed at the previous-generation model** (Oak's find)

The cURL quickstart sent `model: s2-pro`. Worse, this is not just cosmetic for SDK users: the raw API falls back to `s2.1-pro` when the header is absent, but **both SDKs always send a model header and default to `s2-pro`**. Anyone following the Python quickstart was silently running on the old model.

Answering Oak's question directly: yes, the Python SDK's default is a non-free, previous-generation model.

**3. Stale SDK claims in the TTS feature page**

`features/text-to-speech.mdx` claimed the JS SDK defaults to `s1` (it is `s2-pro`).

## Changes

- Warn about the package-vs-import name and the squatted `fishaudio` package on both quickstarts and in the bundled `fish-audio-sdk` skill.
- Pass `model` explicitly in every quickstart example; document `s2.1-pro-free`.
- Note the JS SDK's `Backends` type cannot yet express the S2.1 models.
- Correct the stale SDK-default claims.
- Document why `402` happens on the *free* model (see below).

## The `402` on `s2.1-pro-free` is a backend behaviour, not a docs bug

I traced it. `s2.1-pro-free` is priced at `Decimal("0.0")`, but the credit gate runs *before* pricing and is model-independent:

- `apps/openapis/schemas.py` — `has_credit = normalized_credit > Decimal(0)`
- `apps/wallets/models.py:1391` — `APICredit.initialize` seeds `credit = Decimal(0)`

So every new account starts at zero API balance and gets `402` on its first call, including on the $0 model. The free plan's 8,000 credits (`FREE_PACKAGE_PACKAGE_CREDIT`) are the web-app package, not the API wallet.

This PR only *documents* the behaviour. **The product decision Cale raised — that a free model should not require a funded wallet — is not addressed here** and needs a separate change in `platform-api` (e.g. skip the balance gate when the resolved backend price is `0`).

## Verification

- Reproduced the `ImportError` in a clean venv.
- Confirmed against published `fish-audio-sdk` 1.3.0: `convert(model=...)` is annotated `Literal['speech-1.5','speech-1.6','s1','s2-pro']` and defaults to `s2-pro`. Arbitrary strings are accepted at runtime (it is just a header), so `model="s2.1-pro"` works today — type checkers will flag it until a release ships.
- Rendered both quickstarts with `mint dev`; `mint broken-links` reports no new breakage.

## Related follow-ups (not in this PR)

- **`fish-audio-python`:** the `s2.1-pro` default and `Union[Model, str]` widening landed in `4481509` but are **unreleased** — the newest tag is `fish-audio-sdk-v1.3.0`. Cutting a release would let the docs drop the "pass it explicitly" caveat.
- **`fish-audio-typescript`:** `Backends` omits `s2.1-pro` / `s2.1-pro-free` and still defaults to `s2-pro`.
- Other `s2-pro` samples remain across `features/` and `api-reference/`; kept out of scope to keep this reviewable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788931879&installation_model_id=430858&pr_number=129&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F129&signature=76a9f712e5c62b7e004ac34d1c832ca5e9be3cf9297230b13cf98d78f36baf48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->