### PR TITLE
docs: update API billing link

### DIFF
--- a/api-reference/errors.mdx
+++ b/api-reference/errors.mdx
@@ -18,7 +18,7 @@ Every Fish Audio error comes back as JSON with a `message` and a `status`:
 |---|---|---|
 | `400` | Bad request — invalid parameters, or a `reference_id` / voice that doesn't exist | Fix the request; read the `message`. |
 | `401` | Invalid or missing API key | Send `Authorization: Bearer <key>`; check it on [API Keys](https://fish.audio/app/api-keys). |
-| `402` | Insufficient credits | Top up on [Billing](https://fish.audio/app/billing). |
+| `402` | Insufficient credits | Top up on [API Billing](https://fish.audio/app/developers/billing/). |
 | `403` | Not permitted for this key/resource | Check the key's scope and the resource owner. |
 | `404` | Model or voice not found | Verify the `model_id` / `reference_id`. |
 | `429` | Rate limit exceeded | Back off and retry (see below). |


### PR DESCRIPTION
## Summary

- Update the billing link for `402 Insufficient credits`
- Point users to the new API Billing page

## Testing

- Verified the documentation change locally

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789105993&installation_model_id=430858&pr_number=134&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F134&signature=52cb31991434ad2076f8db26c4ad3ac20bfc3cfcd4926fa4f719856a94497674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the 402 error guidance to link directly to the API Billing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->