### PR TITLE
docs(telephony): phone number search now covers US and Canada

### DIFF
--- a/agents/telephony/phone-numbers.mdx
+++ b/agents/telephony/phone-numbers.mdx
@@ -19,9 +19,9 @@ The response is an `available_phone_numbers` array of inventory entries forwarde
 
 | Parameter      | Description                                                                                                                                |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `country_code` | ISO 3166-1 alpha-2 country code. Default `US`.                                                                                             |
+| `country_code` | ISO 3166-1 alpha-2 country code, `US` (default) or `CA`.                                                                                   |
 | `area_code`    | Restrict results to one area code, like `415`.                                                                                             |
-| `number_type`  | `local` (default). The managed inventory is US local numbers only; `toll_free` returns `400`.                                              |
+| `number_type`  | `local` (default). The managed inventory is US and Canada local numbers only; `toll_free` returns `400`.                                   |
 | `provider`     | Inventory to search. Only `twilio` (the default) is available — managed numbers with [call transfer](/agents/telephony/transfers) support. |
 
 <Note>


### PR DESCRIPTION
## Summary
- Update the phone-numbers page's search parameter table: `country_code` accepts `US` (default) or `CA`, and the managed inventory note now says US and Canada local numbers.
- `api-reference/openapi.json` is not touched — it auto-updates from the deployed API schema.

Documents fishaudio/platform-api#1357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789125419&installation_model_id=430858&pr_number=135&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F135&signature=324eb36dcbcf85ec44ef42148257af7ed6425cb59b301746b24a12552c70114f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that available phone numbers can be searched in the US and Canada.
  * Documented that managed local-number inventory covers both countries.
  * Confirmed that toll-free numbers remain unsupported and return a 400 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->