### PR TITLE
Document text-only default for typed turns

### DIFF
--- a/agents/deploy/protocol.mdx
+++ b/agents/deploy/protocol.mdx
@@ -130,7 +130,7 @@ Publish these on the `client-event` topic. The agent ignores malformed JSON and 
 }
 ```
 
-- `user.message` gets **no server echo** — you already hold the text, so render the bubble locally. Add `"audio": false` to have the agent answer that turn in text only: no speech is synthesized and the reply arrives over transcription.
+- `user.message` gets **no server echo** — you already hold the text, so render the bubble locally. Add `"audio": false` to have the agent answer that turn in text only: no speech is synthesized and the reply arrives over transcription. When the field is absent the agent speaks as usual; note the web SDK's `sendUserMessage` sends `"audio": false` unless called with `audio: true`.
 - `client_tool.result` may carry `result` (any JSON value) or `"isError": true` to report the tool as failed to the model. Results for unknown or already-settled `callId`s are ignored.
 
 ## Transcription and agent state

--- a/agents/deploy/react-sdk.mdx
+++ b/agents/deploy/react-sdk.mdx
@@ -121,7 +121,7 @@ See [Authenticated sessions](/agents/deploy/authenticated-sessions) for the back
 | `session`                         | The live `AgentSession` object (`null` before the first start) for direct event access    |
 
 <Tip>
-`sendUserMessage(text)` injects a typed turn; the agent's reply streams back as transcript and audio. Pass `{ audio: false }` to get a text-only reply for that turn — useful for a do-not-disturb typing mode.
+`sendUserMessage(text)` injects a typed turn; the agent replies in text only by default — the reply streams back as transcript with no speech. Pass `{ audio: true }` to have the agent speak its reply for that turn.
 </Tip>
 
 For transcripts, tool-call events, and error handling, subscribe to events on `session` — see the [Web SDK event reference](/agents/deploy/web-sdk).

--- a/agents/deploy/web-sdk.mdx
+++ b/agents/deploy/web-sdk.mdx
@@ -156,11 +156,12 @@ Users can type instead of talking, in the same session:
 ```javascript Text input
 // Send a typed user turn. There is no server echo — the SDK emits
 // the finalized `message` event locally from the text you passed.
+// By default the agent answers a typed turn in text only
+// (agentResponseDelta / agentResponse) without speaking out loud.
 session.sendUserMessage("Do you ship to Norway?");
 
-// Text-only reply for this turn: the agent answers in text
-// (agentResponseDelta / agentResponse) without speaking out loud.
-session.sendUserMessage("What's my order status?", { audio: false });
+// Pass `audio: true` to have the agent speak its reply for this turn.
+session.sendUserMessage("What's my order status?", { audio: true });
 
 // Signal typing so the agent doesn't talk over the user.
 input.addEventListener("input", () => session.sendUserActivity());
@@ -168,6 +169,8 @@ input.addEventListener("input", () => session.sendUserActivity());
 // Stop the agent's current speech immediately (explicit barge-in).
 session.interrupt();
 ```
+
+Text-only replies are not paced to audio playback — the transcript streams as fast as it generates.
 
 ## Audio controls
 


### PR DESCRIPTION
## Summary
- `web-sdk.mdx` Send text section: typed turns now default to a text-only reply; `{ audio: true }` opts into speech. Adds a note that text-only replies stream without playback pacing.
- `react-sdk.mdx`: `sendUserMessage` description updated to the new default.
- `protocol.mdx`: wire semantics unchanged (absent `audio` still means a spoken reply); adds a note that the web SDK sends `audio: false` unless called with `audio: true`.

Companion SDK change: fishaudio/fish-agent-sdk-web#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789125936&installation_model_id=430858&pr_number=136&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F136&signature=675f225cbfd40e01bcc9c47611265bef3c667fcdf99246199efb12577682bf03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->