### PR TITLE
docs(agents): expressive mode — voice.expressive toggle (FA-239)

### DIFF
--- a/agents/build/configuration.mdx
+++ b/agents/build/configuration.mdx
@@ -32,7 +32,7 @@ Choose how the agent opens each conversation:
 
 ## Voice
 
-The Voice panel selects the voice your agent speaks with (`voice_id`) and its speaking language (`speaking_language`: `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`). See [Voice & language](/agents/build/voice-language) for picking a voice.
+The Voice panel selects the voice your agent speaks with (`voice_id`), its speaking language (`speaking_language`: `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`), and whether it speaks expressively (`expressive`, default `false`). See [Voice & language](/agents/build/voice-language) for picking a voice and [Expressive mode](/agents/build/voice-language#expressive-mode) for expressive delivery.
 
 ## Conversation settings
 
@@ -130,7 +130,7 @@ The response includes the draft's new `config_hash`. Values outside the document
 | Section | What it holds | Documented in |
 |---|---|---|
 | `prompt` | System prompt and first-message settings | This page |
-| `voice` | Voice profile and speaking language | [Voice & language](/agents/build/voice-language) |
+| `voice` | Voice profile, speaking language, and expressive mode | [Voice & language](/agents/build/voice-language) |
 | `conversation` | Call duration, turn-taking, interruption behavior, timezone, and storage | This page; storage in [Conversation history](/agents/monitor/conversation-history#what-gets-stored) |
 | `tools` | Attached webhook tools and system tool switches | [Tools](/agents/build/tools) |
 | `knowledge_base` | Attached knowledge sources | [Knowledge base](/agents/build/knowledge-base) |

--- a/agents/build/voice-language.mdx
+++ b/agents/build/voice-language.mdx
@@ -73,6 +73,31 @@ curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
 
 Both settings can also be replaced for a single session — send `overrides.voice_id` or `overrides.language` on the session request. See [Overrides](/agents/deploy/authenticated-sessions#overrides).
 
+## Expressive mode
+
+**Expressive mode** makes the agent steer its own delivery: it opens sentences with emotion cues, adds natural pauses and emphasis, laughs where it genuinely fits, and speaks the way people talk — contractions and the occasional "um". You get lively, emotionally aware speech without writing any delivery rules into your prompt.
+
+Turn it on with the **Expressive mode** switch in the Builder's voice section, or via the API (`voice.expressive`, default `false`):
+
+<CodeGroup>
+```bash API (curl)
+curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "voice": {
+      "expressive": true
+    }
+  }'
+```
+</CodeGroup>
+
+The delivery cues are rendered by the voice model — they are never spoken and never appear in transcripts or message history. Expressive mode applies to spoken sessions (voice calls and phone); text chat is unaffected.
+
+<Tip>
+  Keep your system prompt about **what** the agent says — who it is, what it knows, what it should do. With expressive mode on, **how** it sounds is handled for you.
+</Tip>
+
 ## Going further
 
 <CardGroup cols={2}>


### PR DESCRIPTION
Linear: [FA-239](https://linear.app/39ai/issue/FA-239/option-to-enable-expressive-mode)

Documents the new Expressive mode toggle: a section on the Voice & Language page (what it does, `voice.expressive` PATCH example, transcript behavior, spoken-only scope) and the Configuration page's voice-section references.

Publish alongside the feature (fishaudio/fish-agent#49 + the platform-api/platform-web PRs of the same branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789228249&installation_model_id=430858&pr_number=141&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F141&signature=a24acaa56cf92a29a9ce8c1ba2ddbcf8282720ebc2d53a8f246ce7abf77b9123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the new Expressive voice setting for agents, including its default disabled state.
  - Added Expressive mode to the voice configuration reference.
  - Explained how to enable Expressive mode through Builder and API configuration.
  - Clarified delivery characteristics, transcript visibility, and session scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->