### PR TITLE
docs: remove Version history section from Wire Protocol page

### DIFF
--- a/agents/deploy/protocol.mdx
+++ b/agents/deploy/protocol.mdx
@@ -150,13 +150,6 @@ These ride the transport's built-in mechanisms rather than custom messages.
 2. **Evolution is additive-only.** Published fields never change name or meaning and are never removed; new fields are always optional. A semantic change ships as a new `type`.
 3. **No replay.** Data-channel delivery is reliable and ordered within a connection, but after a reconnect or late join, missed messages are gone. Never wait for history. Tool terminal messages repeat their identifying fields, and the state attribute is sticky, precisely to soften this.
 
-## Version history
-
-| Version         | Changes                                                                                                                                            |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 0.0.1           | Initial public release: the complete message set on this page, including tool lifecycle events and the optional `audio` flag on `user.message`    |
-| 0.1.0 (current) | Revised the session-creation `SessionOverrides` shape; realtime messages unchanged                                                                 |
-
 ## Going further
 
 <CardGroup cols={2}>


### PR DESCRIPTION
Removes the **Version history** section (heading + version table) from the Wire Protocol page (`agents/deploy/protocol.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790417303&installation_model_id=430858&pr_number=155&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F155&signature=58e18e32b67687a9081b5dc844189245fb9596022f768109f4312b76884b35f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->