### PR TITLE
docs(agents): runnable quickstart sample, callback names, and beta access note

### DIFF
--- a/agents/deploy/authenticated-sessions.mdx
+++ b/agents/deploy/authenticated-sessions.mdx
@@ -52,7 +52,7 @@ curl --request POST https://api.fish.audio/v1/agent/sessions \
 ```
 
 ```javascript Backend (Express)
-app.post("/voice-session", async (req, res) => {
+app.post("/api/voice-session", async (req, res) => {
   const upstream = await fetch("https://api.fish.audio/v1/agent/sessions", {
     method: "POST",
     headers: {
@@ -98,7 +98,7 @@ On the client, fetch the token from your backend and pass it to the SDK unchange
 ```javascript Browser
 import { AgentSession } from "@fishaudio/agent-client";
 
-const sessionToken = await fetch("/voice-session", { method: "POST" }).then(r =>
+const sessionToken = await fetch("/api/voice-session", { method: "POST" }).then(r =>
   r.json()
 );
 

--- a/agents/overview.mdx
+++ b/agents/overview.mdx
@@ -7,6 +7,12 @@ icon: "robot"
 
 Fish Agents is a hosted platform for real-time voice agents. Define an agent's prompt, voice, knowledge, and tools in the Builder console, publish it, and talk to it from your web app through the SDK, over a phone number, or anywhere the REST API reaches. Speech recognition, turn-taking, and speech synthesis are handled for you.
 
+<Note>
+  Agents is in private beta. Open [Agents](https://fish.audio/app/agents) in
+  the console to apply for access. Until access is granted on your account, the
+  Agents pages and every `/v1/agent/*` request return `403`.
+</Note>
+
 <CardGroup cols={3}>
   <Card title="Quickstart" icon="rocket" href="/agents/quickstart">
     Create an agent and have your first conversation in minutes.

--- a/agents/quickstart.mdx
+++ b/agents/quickstart.mdx
@@ -8,8 +8,9 @@ Build a voice agent and talk to it in a few minutes. Use the console for a no-co
 
 **Prerequisites**
 
-- A Fish Audio account
+- A Fish Audio account with access to Agents. Agents is in private beta: open [Agents](https://fish.audio/app/agents) in the console and apply for access if you do not have it yet. Until access is granted, the Agents pages and every `/v1/agent/*` request return `403`.
 - For the API path: a Fish Audio API key. Create one under [API keys](https://fish.audio/app/api-keys/) in the console
+- Every account starts with 60 free minutes of agent conversation, shared across web, phone, and preview calls that leave the Builder. After that, sessions are billed per second against your API credit.
 
 <Tabs>
   <Tab title="Dashboard">
@@ -116,8 +117,8 @@ Build a voice agent and talk to it in a few minutes. Use the console for a no-co
         const session = await AgentSession.start({
           sessionToken,
           callbacks: {
-            userTranscript: ({ text }) => console.log("You:", text),
-            agentResponse: ({ text }) => console.log("Agent:", text),
+            onUserTranscript: ({ text }) => console.log("You:", text),
+            onAgentResponse: ({ text }) => console.log("Agent:", text),
           },
         });
 
@@ -128,7 +129,13 @@ Build a voice agent and talk to it in a few minutes. Use the console for a no-co
         Start talking. You hear the agent reply and both sides of the conversation arrive as transcript events. See the [Web SDK](/agents/deploy/web-sdk) for the full event and method surface, or the [React SDK](/agents/deploy/react-sdk) for hooks.
       </Step>
       <Step title="Put it together">
-        The whole loop is two files: a backend route that creates the session with your API key, and frontend code that starts the call. Run the server with `FISH_API_KEY` and `AGENT_ID` set, serve the frontend from your app's dev server (Vite, Next, or anything that bundles npm imports), and talk.
+        A complete local setup is one backend route that creates the session with your API key, and a page that starts the call. The frontend is served by Vite, which also proxies `/api` to the backend so the browser never sees your key.
+
+        ```bash Install
+        npm init -y
+        npm install express @fishaudio/agent-client
+        npm install --save-dev vite
+        ```
 
         ```javascript server.mjs
         import express from "express";
@@ -145,31 +152,69 @@ Build a voice agent and talk to it in a few minutes. Use the console for a no-co
             body: JSON.stringify({ agent_id: process.env.AGENT_ID }),
           });
           if (!upstream.ok) {
+            console.error("session creation failed:", upstream.status);
             return res.status(502).json({ error: "session_unavailable" });
           }
           res.json(await upstream.json());
         });
 
-        app.listen(3001);
+        app.listen(3001, () => console.log("backend on http://localhost:3001"));
+        ```
+
+        ```javascript vite.config.mjs
+        export default {
+          server: {
+            proxy: { "/api": "http://localhost:3001" },
+          },
+        };
+        ```
+
+        ```html index.html
+        <!doctype html>
+        <button id="start">Start call</button>
+        <button id="end" disabled>Hang up</button>
+        <pre id="log"></pre>
+        <script type="module" src="/main.js"></script>
         ```
 
         ```javascript main.js
         import { AgentSession } from "@fishaudio/agent-client";
 
-        const sessionToken = await fetch("/api/voice-session", {
-          method: "POST",
-        }).then(r => r.json());
+        const startButton = document.getElementById("start");
+        const endButton = document.getElementById("end");
+        const log = (line) => (document.getElementById("log").textContent += line + "\n");
 
-        const session = await AgentSession.start({
-          sessionToken,
-          callbacks: {
-            userTranscript: ({ text }) => console.log("You:", text),
-            agentResponse: ({ text }) => console.log("Agent:", text),
-          },
-        });
+        let session;
+
+        // Start from a click: browsers only grant the microphone and
+        // audio playback inside a user gesture.
+        startButton.onclick = async () => {
+          const sessionToken = await fetch("/api/voice-session", { method: "POST" })
+            .then((r) => r.json());
+
+          session = await AgentSession.start({
+            sessionToken,
+            callbacks: {
+              onUserTranscript: ({ text, final }) => final && log("You: " + text),
+              onAgentResponse: ({ text }) => log("Agent: " + text),
+              onDisconnect: ({ reason }) => log("Call ended: " + reason),
+            },
+          });
+          startButton.disabled = true;
+          endButton.disabled = false;
+        };
+
+        endButton.onclick = () => session?.end();
         ```
 
-        Every request and response on this path is in the [Agents API reference](/api-reference/endpoint/agent/create-agent-session).
+        Run the two processes in separate terminals, then open the Vite URL (`http://localhost:5173`) and click **Start call**:
+
+        ```bash Run
+        FISH_API_KEY=your_key AGENT_ID=your_agent_id node server.mjs
+        npx vite
+        ```
+
+        Every request and response on this path is in the [Agents API reference](/api-reference/endpoint/agent/create-agent-session). For production, keep the same shape: your backend owns the API key and returns session tokens, and the SDK runs in the page.
       </Step>
     </Steps>
 


### PR DESCRIPTION
- Quickstart "Put it together" is now a complete local project: install commands, Express backend, Vite config with the `/api` proxy, `index.html`, and a `main.js` that starts the call from a click. Tested locally end to end.
- Callback keys use the SDK's `on*` form (`onUserTranscript`, `onAgentResponse`).
- Prerequisites mention the private beta access request and the free minutes; the same beta note is on the Agents overview.
- Authenticated sessions sample uses `/api/voice-session`, matching the quickstart and React pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791187563&installation_model_id=430858&pr_number=161&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F161&signature=fc29bf828286aa54f6de73078814551f533c25a709cc83ac1861b053dc897e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->