### PR TITLE
docs(agents): complete the Web SDK and React SDK references

### DIFF
--- a/agents/deploy/react-sdk.mdx
+++ b/agents/deploy/react-sdk.mdx
@@ -4,11 +4,11 @@ description: "Add voice conversations to your React app with hooks and drop-in c
 icon: "react"
 ---
 
-`@fishaudio/agent-react` wraps the [Web SDK](/agents/deploy/web-sdk) in idiomatic React: a `useConversation` hook for session control, an optional provider that shares one session across your component tree, and a ready-made audio visualizer. The SDK handles microphone capture, audio playback, and transport internally.
+`@fishaudio/agent-react` wraps the [Web SDK](/agents/deploy/web-sdk) in idiomatic React: a `useConversation` hook for session control, an optional provider that shares one session across your component tree, a streaming chat-log hook, and a ready-made audio visualizer. The SDK handles microphone capture, audio playback, and transport internally. Authentication, events, client tools, and error semantics are the Web SDK's; everything documented there applies here.
 
 <CardGroup cols={3}>
   <Card title="Web SDK reference" icon="js" href="/agents/deploy/web-sdk">
-    Every event, method, and error code.
+    Every option, event, method, and error code.
   </Card>
   <Card
     title="Authenticated sessions"
@@ -38,6 +38,8 @@ yarn add @fishaudio/agent-react
 ```
 
 </CodeGroup>
+
+Requires React 18 or later. The package re-exports the Web SDK's main exports (`AgentSession`, `FishAgentError`, and their types), so app code can import everything from `@fishaudio/agent-react`.
 
 ## Quick start
 
@@ -103,42 +105,142 @@ const sessionToken = await res.json();
 await startSession({ sessionToken });
 ```
 
-See [Authenticated sessions](/agents/deploy/authenticated-sessions) for the backend side. `startSession` accepts the same options as `AgentSession.start` in the [Web SDK](/agents/deploy/web-sdk), including [`clientTools`](/agents/build/client-tools). Session settings such as [`overrides`](/agents/deploy/authenticated-sessions#overrides) and `dynamicVariables` apply when you connect with an `agentId`; with a `sessionToken`, your backend sets them in its session-creation request instead.
+See [Authenticated sessions](/agents/deploy/authenticated-sessions) for the backend side. `startSession` accepts the same options as `AgentSession.start` in the [Web SDK](/agents/deploy/web-sdk#options), including [`clientTools`](/agents/build/client-tools). Session settings such as [`overrides`](/agents/deploy/authenticated-sessions#overrides) and `dynamicVariables` apply when you connect with an `agentId`; with a `sessionToken`, your backend sets them in its session-creation request instead.
 
-## What `useConversation` returns
+### Next.js
 
-| Field                             | Description                                                                               |
-| --------------------------------- | ----------------------------------------------------------------------------------------- |
-| `startSession(options)`           | Create and connect a session (`agentId` or `sessionToken`)                                |
-| `endSession()`                    | Hang up gracefully                                                                        |
-| `status`                          | `"idle"` (no session yet) / `"connecting"` / `"connected"` / `"reconnecting"` / `"ended"` |
-| `mode`                            | `"listening"` / `"thinking"` / `"speaking"`                                               |
-| `isSpeaking`                      | `true` while the agent is audibly speaking                                                |
-| `micMuted`, `setMicMuted(muted)`  | Microphone mute state                                                                     |
-| `sendUserMessage(text, options?)` | Send a typed message as a user turn                                                       |
-| `sendUserActivity()`              | Signal that the user is typing, so the agent holds back                                   |
-| `interrupt()`                     | Explicitly stop the agent mid-response                                                    |
-| `session`                         | The live `AgentSession` object (`null` before the first start) for direct event access    |
+The SDK only touches browser APIs when a session starts, so importing it in Server Components is safe, but any component that calls the hooks needs the `"use client"` directive. Create session tokens in a Route Handler so your API key stays on the server:
 
-<Tip>
-`sendUserMessage(text)` injects a typed turn; the agent replies in text only by default; the reply streams back as transcript. Pass `{ audio: true }` to have the agent speak its reply for that turn.
-</Tip>
+<CodeGroup>
 
-For transcripts, tool-call events, and error handling, subscribe to events on `session`. See the [Web SDK event reference](/agents/deploy/web-sdk).
+```ts app/api/voice-session/route.ts
+export async function POST() {
+  const upstream = await fetch("https://api.fish.audio/v1/agent/sessions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.FISH_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ agent_id: process.env.FISH_AGENT_ID }),
+  });
+  if (!upstream.ok) {
+    return Response.json({ error: "session_unavailable" }, { status: 502 });
+  }
+  return Response.json(await upstream.json());
+}
+```
+
+```tsx app/call-button.tsx
+"use client";
+
+import { useConversation } from "@fishaudio/agent-react";
+
+export function CallButton() {
+  const { startSession, status } = useConversation();
+
+  const start = async () => {
+    const sessionToken = await fetch("/api/voice-session", { method: "POST" })
+      .then(r => r.json());
+    await startSession({ sessionToken });
+  };
+
+  return (
+    <button disabled={status === "connecting"} onClick={start}>
+      Start call
+    </button>
+  );
+}
+```
+
+</CodeGroup>
+
+Start calls made from a user interaction are safe under React Strict Mode's effect replay.
+
+## `useConversation(defaults?)`
+
+Owns one session's lifecycle and re-renders on its state changes. `defaults` is merged into every `startSession(overrides?)` call, with `overrides` winning per key. Put long-lived options such as `clientTools`, `callbacks`, or a public `agentId` in `defaults`, and per-call values such as a freshly fetched `sessionToken` in `overrides`. The latest render's `defaults` are used, so inline objects are fine.
+
+```tsx
+const conversation = useConversation({
+  clientTools: { open_page: ({ page }) => showPanel(String(page)) },
+  callbacks: { onDisconnect: ({ reason }) => showCallEnded(reason) },
+});
+
+const start = async () => {
+  const sessionToken = await fetch("/api/voice-session", { method: "POST" })
+    .then(r => r.json());
+  await conversation.startSession({ sessionToken });
+};
+```
+
+### Returned value
+
+| Field                             | Type                                     | Description                                                                                                                                                                                                                                 |
+| --------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `startSession(overrides?)`        | `(overrides?) => Promise<string>`        | Create and connect a session (`agentId` or `sessionToken`); resolves with the session id                                                                                                                                                    |
+| `endSession()`                    | `() => Promise<void>`                    | Hang up gracefully. Safe to call at any time                                                                                                                                                                                                |
+| `status`                          | `"idle" \| SessionStatus`                | `"idle"` before the first start and after a failed start, then `"connecting"` / `"connected"` / `"reconnecting"` / `"ended"`                                                                                                              |
+| `mode`                            | `AgentMode`                              | `"listening"` / `"thinking"` / `"speaking"`; drive a talking-orb UI with this                                                                                                                                                              |
+| `isSpeaking`                      | `boolean`                                | `true` while the agent is audibly speaking                                                                                                                                                                                                  |
+| `micMuted`, `setMicMuted(muted)`  | `boolean`, `(muted) => Promise<void>`    | Microphone mute state. After a `microphone: false` start it begins `true`, and the first unmute captures the microphone                                                                                                                    |
+| `sendUserMessage(text, options?)` | `(text, { audio? }?) => void`            | Send a typed message as a user turn. The agent replies in text only by default; pass `{ audio: true }` to have it speak the reply. Pair with [`useAgentMessages`](#chat-log-with-useagentmessages) for a chat UI                             |
+| `sendUserActivity()`              | `() => void`                             | Signal that the user is typing, so the agent holds back                                                                                                                                                                                     |
+| `interrupt()`                     | `() => void`                             | Explicitly stop the agent mid-response                                                                                                                                                                                                      |
+| `startAudio()`                    | `() => Promise<void>`                    | Unlock playback inside a user gesture if autoplay was blocked                                                                                                                                                                               |
+| `setOutputVolume(volume)`         | `(volume) => void`                       | Playback volume, `0` to `1`                                                                                                                                                                                                                 |
+| `setInputDevice(deviceId)`        | `(deviceId) => Promise<void>`            | Switch the microphone mid-call. Rejects with `device_change_failed` if the device cannot be activated. No-op before the first start                                                                                                        |
+| `setOutputDevice(deviceId)`       | `(deviceId) => Promise<void>`            | Route playback to another output device (`""` for the default). Rejects with `device_change_failed` where unsupported (common on mobile browsers). No-op before the first start; for a pre-call pick, pass `audio.outputDeviceId` to `startSession` |
+| `session`                         | `AgentSession \| null`                   | The live `AgentSession` object (`null` before the first start) for direct `.on(...)` event access                                                                                                                                          |
+
+For transcripts, tool-call events, and error handling, subscribe to events on `session` or pass `callbacks` in `defaults`. See the [Web SDK event reference](/agents/deploy/web-sdk#events).
+
+### Lifecycle details
+
+- **Double-start safe.** If a session is already live, `startSession` resolves with its id instead of starting a second one; two concurrent calls (a double-click) share one start.
+- **Hangup-during-start safe.** Calling `endSession` while a start is still waiting on session creation, the microphone permission, or the realtime connection marks the conversation ended and waits for that start to settle; a late connection is closed before the hook exposes it. A `startSession` requested during that cleanup waits, then creates a fresh session. If another `endSession` cancels that queued restart, it rejects with an error whose `name` is `"AbortError"`.
+- **Failure resets.** If `startSession` rejects (see [Errors](/agents/deploy/web-sdk#errors)), `status` returns to `"idle"` and the hook is ready for another attempt:
+
+  ```tsx
+  try {
+    await conversation.startSession({ sessionToken });
+  } catch (error) {
+    if (error instanceof FishAgentError && error.code === "mic_permission_denied") {
+      showMicHelp();
+    }
+  }
+  ```
+
+- **Unmount ends the call.** No leaked microphones after navigation. Keep the component mounted for the call's duration; lift it up, or use the [provider](#share-one-session-across-components), if the page around it changes.
+- The message senders (`sendUserMessage`, `sendUserActivity`, `interrupt`) are no-ops before the session connects; they do not queue.
 
 ## Share one session across components
 
-Wrap your tree in `AgentSessionProvider` when several components need the same conversation: call controls in the header, a transcript panel elsewhere.
+Wrap your tree in `AgentSessionProvider` when several components need the same conversation: call controls in the header, a transcript panel elsewhere. The provider hosts one `useConversation(options)`, so its `options` prop takes the hook's `defaults`.
 
 ```tsx App.tsx
-import { AgentSessionProvider, useAgentMessages } from "@fishaudio/agent-react";
+import {
+  AgentSessionProvider,
+  useAgentSessionContext,
+  useAgentMessages,
+  AgentAudioVisualizer,
+} from "@fishaudio/agent-react";
 
 export function App() {
   return (
-    <AgentSessionProvider>
-      <CallButton />
+    <AgentSessionProvider options={{ agentId: "YOUR_AGENT_ID" }}>
+      <CallControls />
       <Transcript />
+      <AgentAudioVisualizer bars={24} />
     </AgentSessionProvider>
+  );
+}
+
+function CallControls() {
+  const { status, startSession, endSession } = useAgentSessionContext();
+  return status === "connected" ? (
+    <button onClick={() => endSession()}>Hang up</button>
+  ) : (
+    <button onClick={() => startSession()}>Start call</button>
   );
 }
 
@@ -157,33 +259,115 @@ function Transcript() {
 }
 ```
 
-The provider hosts the conversation, so components inside it read the shared state with `useAgentSessionContext()` instead of calling `useConversation` themselves. It returns the same fields, so the quick-start `CallButton` only needs its hook call swapped.
+Components inside the provider read the shared state with `useAgentSessionContext()` instead of calling `useConversation` themselves. It returns the same fields, so the quick-start `CallButton` only needs its hook call swapped.
 
-| Hook                             | Purpose                                                                                                                                 |
-| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `useAgentSessionContext()`       | Access the active session from anywhere inside the provider                                                                             |
-| `useAgentMessages()`             | Live conversation as a list of `{ key, role, text, final }` messages: segments update in place as they stream, no manual aggregation   |
-| `useAudioLevels(session?, fps?)` | Live input and output volume as `{ input, output }` (0–1), polled `fps` times per second (default 20); lower `fps` to reduce re-renders |
+| Hook                               | Purpose                                                                                                          |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `useAgentSessionContext()`         | The nearest provider's conversation (the same value `useConversation` returns). Throws outside a provider        |
+| `useOptionalAgentSessionContext()` | Nullable variant, for components that also work standalone                                                       |
 
-## Audio visualizer
+The session-consuming hooks and components (`useAgentMessages`, `useAudioLevels`, `<AgentAudioVisualizer />`) all resolve their session the same way: pass one explicitly (`useAgentMessages(session)`) or omit the argument to use the surrounding provider's. Passing `null` explicitly means "no session"; it does not fall back to the provider.
 
-`<AgentAudioVisualizer>` renders animated canvas bars driven by the agent's output audio, a drop-in "the agent is talking" indicator. Inside an `AgentSessionProvider` it picks up the active session automatically; elsewhere, pass a `session` prop. Optional `bars`, `width`, `height`, and `className` props control the rendering, and the bars follow the element's CSS `color`.
+## Chat log with `useAgentMessages`
+
+`useAgentMessages(session?)` returns the conversation as a live list of `ChatMessage` entries in order, aggregated from the session's transcript events so you do not have to reduce them yourself:
+
+| Field   | Type                  | Description                                          |
+| ------- | --------------------- | ---------------------------------------------------- |
+| `key`   | `string`              | Stable per-turn key; use it as the React list key    |
+| `role`  | `"user" \| "agent"`   | Who is speaking                                      |
+| `text`  | `string`              | The whole turn so far (not a delta)                  |
+| `final` | `boolean`             | `false` while the turn is still streaming            |
+
+- A user turn appears as soon as transcription starts and its `text` is refined in place; always re-render from `text`, never append.
+- An agent turn grows with each response delta and flips to `final: true` when the turn completes.
+- Both directions update the existing entry (matched by `key`), so the array's order and identity are stable for React reconciliation.
+- Mounting mid-session backfills from `session.getTranscript()`, so turns that streamed before the component subscribed still appear, without duplicates.
+- The log resets when a new session starts. Persist it yourself (for example into app state on `disconnect`) if you need history across calls.
+- Events dropped during a reconnection are not replayed, so the log may skip turns lost to an outage.
+
+```tsx Voice and text chat panel
+import { useState } from "react";
+import { useAgentMessages, useAgentSessionContext } from "@fishaudio/agent-react";
+
+function ChatPanel() {
+  const { status, sendUserMessage, sendUserActivity } = useAgentSessionContext();
+  const messages = useAgentMessages();
+  const [draft, setDraft] = useState("");
+
+  const submit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!draft.trim()) return;
+    sendUserMessage(draft); // shows up in `messages` like a spoken turn
+    setDraft("");
+  };
+
+  return (
+    <div>
+      <ul>
+        {messages.map(message => (
+          <li key={message.key} style={{ opacity: message.final ? 1 : 0.6 }}>
+            <b>{message.role}:</b> {message.text}
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={submit}>
+        <input
+          value={draft}
+          disabled={status !== "connected"}
+          onChange={event => {
+            setDraft(event.target.value);
+            sendUserActivity(); // hold the agent back while the user types
+          }}
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+}
+```
+
+If you only want finalized messages in order, without streaming updates, subscribe to the session's [`message` event](/agents/deploy/web-sdk#events) directly instead.
+
+## Audio levels and visualizer
+
+`useAudioLevels(session?, fps?)` returns polled `{ input, output }` levels in `0` to `1`: `input` is the microphone, `output` is the agent's voice. It samples 20 times per second by default; raise `fps` for snappier meters, lower it to reduce re-renders. Both are `0` before the session connects.
+
+```tsx Microphone meter
+function MicMeter() {
+  const { input } = useAudioLevels();
+  return (
+    <div style={{ width: 120, background: "#eee" }}>
+      <div style={{ width: `${input * 100}%`, height: 8, background: "#22c55e" }} />
+    </div>
+  );
+}
+```
+
+`<AgentAudioVisualizer />` renders animated canvas frequency bars driven by the agent's output audio, a drop-in "the agent is talking" indicator. Inside an `AgentSessionProvider` it picks up the active session automatically; elsewhere, pass a `session` prop. The bars are colored by the canvas's CSS `color`, so it themes like text.
 
 ```tsx
 import { AgentAudioVisualizer } from "@fishaudio/agent-react";
 
 function CallScreen() {
-  return <AgentAudioVisualizer />;
+  return <AgentAudioVisualizer bars={32} width={320} height={80} className="agent-bars" />;
 }
 ```
 
-For a custom visualization, build on `useAudioLevels` or the session's frequency-data methods from the [Web SDK](/agents/deploy/web-sdk).
+| Prop               | Type                    | Default      | Description                                                        |
+| ------------------ | ----------------------- | ------------ | ------------------------------------------------------------------ |
+| `session`          | `AgentSession \| null`  | provider's   | Explicit session, or omit to use the provider's                    |
+| `bars`             | `number`                | `24`         | Number of frequency bars                                           |
+| `width` / `height` | `number`                | `240` / `64` | Canvas size in pixels                                              |
+| `className`        | `string`                |              | Passed to the `<canvas>`; set `color` through it to theme the bars |
+
+For a fully custom visualization, build on `useAudioLevels` or the session's frequency-data methods from the [Web SDK](/agents/deploy/web-sdk#audio-controls).
 
 ## Going further
 
 <CardGroup cols={2}>
   <Card title="Web SDK" icon="js" href="/agents/deploy/web-sdk">
-    Full event and method reference behind these hooks.
+    Full option, event, and method reference behind these hooks.
   </Card>
   <Card title="Client tools" icon="wrench" href="/agents/build/client-tools">
     Let the agent call functions in your app.

--- a/agents/deploy/react-sdk.mdx
+++ b/agents/deploy/react-sdk.mdx
@@ -281,8 +281,8 @@ The session-consuming hooks and components (`useAgentMessages`, `useAudioLevels`
 
 - A user turn appears as soon as transcription starts and its `text` is refined in place; always re-render from `text`, never append.
 - An agent turn grows with each response delta and flips to `final: true` when the turn completes.
-- Both directions update the existing entry (matched by `key`), so the array's order and identity are stable for React reconciliation.
-- Mounting mid-session backfills from `session.getTranscript()`, so turns that streamed before the component subscribed still appear, without duplicates.
+- Both directions update the existing entry (matched by `key`), so list order and keys stay stable across renders.
+- A component mounted mid-session starts from `session.getTranscript()`, so turns that streamed before it subscribed still appear, without duplicates.
 - The log resets when a new session starts. Persist it yourself (for example into app state on `disconnect`) if you need history across calls.
 - Events dropped during a reconnection are not replayed, so the log may skip turns lost to an outage.
 

--- a/agents/deploy/web-sdk.mdx
+++ b/agents/deploy/web-sdk.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Web SDK"
-description: "Voice sessions in the browser with @fishaudio/agent-client: events, transcripts, text input, audio controls, and client tools"
+description: "Voice sessions in the browser with @fishaudio/agent-client: options, events, transcripts, text input, audio controls, client tools, and errors"
 icon: "js"
 ---
 
@@ -55,20 +55,41 @@ const session = await AgentSession.start({ sessionToken });
 
 </CodeGroup>
 
+`start()` resolves once the realtime connection is up and rejects with a [`FishAgentError`](#errors) if session creation, the microphone permission, or the connection fails. Call it from a user gesture (a click handler): browsers only grant the microphone and audio playback inside one.
+
 ### Options
 
-| Option                     | Type                                          | Description                                                                                                                                                                                                                                                                                                                     |
-| -------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `agentId` / `sessionToken` | —                                             | One of the two, required                                                                                                                                                                                                                                                                                                        |
-| `clientTools`              | `Record<string, ClientToolHandler>`           | Handlers for [client tools](/agents/build/client-tools) declared on the agent                                                                                                                                                                                                                                                   |
-| `overrides`                | `SessionOverrides`                            | Per-session config [overrides](/agents/deploy/authenticated-sessions#overrides) (`agentId` mode only; with `sessionToken`, your backend sends them when creating the session). Keyless sessions accept only `voice_id` and `language`; the prompt-shaping fields are rejected with `400`                                       |
-| `dynamicVariables`         | `Record<string, string \| number \| boolean>` | Values for `{{placeholders}}` in the agent config; see [Dynamic variables](/agents/build/dynamic-variables)                                                                                                                                                                                                                    |
-| `language`                 | `string`                                      | Shorthand for overriding the agent's language                                                                                                                                                                                                                                                                                   |
-| `toolEvents`               | `boolean`                                     | Whether tool lifecycle events reach this client (default `true`; `agentId` mode only, with `sessionToken` your backend sets `tool_events`)                                                                                                                                                                                    |
-| `timezone`                 | `string`                                      | IANA timezone for the agent's sense of local time: the top of the [resolution order](/agents/build/time-timezone), overriding the agent's configured timezone. When omitted, the SDK still sends the browser timezone as a lower-priority hint (`client_timezone`), which applies only if the agent has no timezone configured |
-| `worldContext`             | `boolean`                                     | Whether the agent knows the current date and time (default `true`; `agentId` mode only, with `sessionToken` your backend sets `world_context`)                                                                                                                                                                                |
-| `audio`                    | `{ inputDeviceId?, outputDeviceId? }`         | Pick specific microphone and output devices                                                                                                                                                                                                                                                                                     |
-| `callbacks`                | `Partial<AgentSessionCallbacks>`              | Shorthand: each key is auto-subscribed via `.on()`                                                                                                                                                                                                                                                                             |
+| Option                     | Type                                                    | Description                                                                                                                                                                                                                                                                                                                     |
+| -------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agentId` / `sessionToken` | `string` / `SessionToken`                               | Exactly one is required: a public agent id, or the JSON your backend received from `POST /v1/agent/sessions`                                                                                                                                                                                                                    |
+| `serverUrl`                | `string`                                                | API base used in `agentId` mode. Default `https://api.fish.audio`                                                                                                                                                                                                                                                              |
+| `clientTools`              | `Record<string, ClientToolHandler>`                     | Handlers for [client tools](/agents/build/client-tools) declared on the agent                                                                                                                                                                                                                                                   |
+| `clientToolTimeoutMs`      | `number`                                                | Per-handler timeout for client tools, in milliseconds. Default `15000`                                                                                                                                                                                                                                                         |
+| `overrides`                | `SessionOverrides`                                      | Per-session config [overrides](/agents/deploy/authenticated-sessions#overrides) (`agentId` mode only; with `sessionToken`, your backend sends them when creating the session). Keyless sessions accept only `voice_id` and `language`; the prompt-shaping fields are rejected with `400`                                       |
+| `dynamicVariables`         | `Record<string, string \| number \| boolean>`           | Values for `{{placeholders}}` in the agent config; see [Dynamic variables](/agents/build/dynamic-variables) (`agentId` mode only)                                                                                                                                                                                              |
+| `language`                 | `"en" \| "ja" \| "zh" \| "ko" \| "es" \| "fr" \| "de"` | Shorthand for `overrides.language` (`agentId` mode only). Omit it to use the agent's configured [speaking language](/agents/build/voice-language#speaking-language); any other value is rejected with `422`                                                                                                                    |
+| `toolEvents`               | `boolean`                                               | Whether tool lifecycle events reach this client (default `true`; `agentId` mode only, with `sessionToken` your backend sets `tool_events`)                                                                                                                                                                                    |
+| `timezone`                 | `string`                                                | IANA timezone for the agent's sense of local time: the top of the [resolution order](/agents/build/time-timezone), overriding the agent's configured timezone. When omitted, the SDK still sends the browser timezone as a lower-priority hint (`client_timezone`), which applies only if the agent has no timezone configured |
+| `worldContext`             | `boolean`                                               | Whether the agent knows the current date and time (default `true`; `agentId` mode only, with `sessionToken` your backend sets `world_context`)                                                                                                                                                                                |
+| `endUserId`                | `string`                                                | Your identifier for the end user, stored on the session and echoed in [webhooks](/agents/monitor/webhooks) (`agentId` mode only; with `sessionToken` your backend sets `end_user_id`)                                                                                                                                         |
+| `metadata`                 | `object`                                                | Your own key-values, stored on the session record and returned verbatim (`agentId` mode only; with `sessionToken` your backend sets `metadata`)                                                                                                                                                                                |
+| `microphone`               | `boolean`                                               | Capture the microphone on start (default `true`). `false` joins muted with no permission prompt, for text-first UIs; the first `setMicMuted(false)` captures it, so call that from a user gesture                                                                                                                              |
+| `audio`                    | `{ inputDeviceId?, outputDeviceId? }`                   | Pick specific microphone and output devices. `start()` rejects with `device_change_failed` if the output device cannot be selected                                                                                                                                                                                             |
+| `wakeLock`                 | `boolean`                                               | Hold a screen wake lock while the session is live, so long calls survive the phone trying to sleep (default `true`). A denied or unsupported wake lock is silent                                                                                                                                                              |
+| `callbacks`                | `Partial<AgentSessionCallbacks>`                        | Shorthand for `.on()`: each `onXxx` key subscribes the `xxx` [event](#events), so `onUserTranscript` subscribes `userTranscript`. From 0.2.1, a key that is not a known event name throws a `TypeError`                                                                                                                       |
+
+```javascript Callbacks shorthand
+const session = await AgentSession.start({
+  sessionToken,
+  callbacks: {
+    onUserTranscript: ({ text, final }) => renderUserBubble(text, final),
+    onAgentResponseDelta: ({ text }) => renderAgentBubble(text),
+    onModeChange: mode => setOrbState(mode),
+    onDisconnect: ({ reason }) => showCallEnded(reason),
+    onError: error => console.error(error.code),
+  },
+});
+```
 
 ## Session lifecycle
 
@@ -79,15 +100,17 @@ connecting → connected ⇄ reconnecting → ended(reason)
       └───────────(failure)───────────→ ended
 ```
 
+`start()` resolves once the realtime connection is up; the agent itself joins moments later. If it has not joined within 15 seconds, the session emits a `connection_failed` error and ends with reason `connection_lost` instead of idling on a dead call.
+
 When the session ends, `disconnect` fires with a reason (also available as `session.endReason`):
 
 | `EndReason`       | Meaning                                                                                                                                                                                                                        |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `user_hangup`     | You called `session.end()`                                                                                                                                                                                                     |
+| `user_hangup`     | You called `session.end()`, or the user left the page                                                                                                                                                                          |
 | `agent_hangup`    | The server ended the session: the agent hung up (for example via the hang-up [system tool](/agents/build/system-tools)), the session hit its maximum duration, or it was force-ended; the protocol does not distinguish these |
-| `connection_lost` | The connection dropped and could not be recovered                                                                                                                                                                              |
+| `connection_lost` | The connection dropped and could not be recovered, or the agent never joined                                                                                                                                                   |
 
-Brief network drops don't end the session: the SDK moves to `reconnecting` and back to `connected` automatically, reusing the same session.
+Brief network drops don't end the session: the SDK moves to `reconnecting` and back to `connected` automatically, reusing the same session. It never creates a new session, so you never need a fresh token mid-call.
 
 <Warning>
   Events are not replayed after a reconnect. Anything emitted while you were in
@@ -96,6 +119,8 @@ Brief network drops don't end the session: the SDK moves to `reconnecting` and b
   `toolCallFailed` events repeat the tool name and source, so a terminal event
   still renders even if you missed `toolCallStarted`.
 </Warning>
+
+The session also exposes `sessionId` (use it to look up the [conversation record](/agents/monitor/conversation-history) later), `status`, `mode`, `isSpeaking`, `micMuted`, and `endReason` as properties.
 
 ## Events
 
@@ -134,8 +159,14 @@ session.on("disconnect", ({ reason }) => showCallEnded(reason));
 Transcripts on both sides arrive as **segments**, one segment per utterance or response, identified by `segmentId`:
 
 - **User segments**: interim results **replace the entire segment text** (they never append). Render by upserting on `segmentId`; `final: true` marks the segment as finalized.
-- **Agent segments**: text streams in sync with audio playback: what you display matches what the user has actually heard. If the agent is interrupted, the segment finalizes containing only the words that were spoken.
+- **Agent segments**: text streams in sync with audio playback: what you display matches what the user has actually heard. If the agent is interrupted, the segment finalizes containing only the words that were spoken. A reply that spans several speech segments (for example around a tool call) arrives as several segments.
 - The `message` event delivers only finalized messages from both sides, in order. Use it when you want a simple transcript list without handling interim updates.
+
+A listener attached late misses the events fired before it subscribed. `session.getTranscript()` returns every segment so far, as `{ segmentId, role, text, final }` in conversation order: seed your UI from it, then keep applying live events by `segmentId`.
+
+### Tool call lifecycle
+
+Every tool the agent runs (webhook, client, or system tool) emits one `toolCallStarted`, resolved by exactly one `toolCallCompleted` or `toolCallFailed` with the same `callId`. `input` and `output` are JSON strings truncated at 4 KB; parse them only when the matching `*Truncated` flag is `false`. These events carry tool arguments and results into the end user's browser: to keep them off the client, start with `toolEvents: false`, or create the session with `tool_events: false` on your backend.
 
 ## Agent modes
 
@@ -170,19 +201,21 @@ input.addEventListener("input", () => session.sendUserActivity());
 session.interrupt();
 ```
 
-Text-only replies are not paced to audio playback: the transcript streams as fast as it generates.
+Text-only replies are not paced to audio playback: the transcript streams as fast as it generates. Messages sent right after `start()` resolves, before the agent has finished joining, are held and delivered in order once it is ready.
 
 ## Audio controls
 
-| Method / property                                      | Description                                                                                                               |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `setMicMuted(muted)` / `micMuted`                      | Mute or unmute the microphone                                                                                             |
-| `setOutputVolume(v)`                                   | Set playback volume, `0`–`1`                                                                                              |
-| `getInputVolume()` / `getOutputVolume()`               | Current mic / agent volume, `0`–`1`; poll per frame                                                                      |
-| `getInputFrequencyData()` / `getOutputFrequencyData()` | FFT data as `Uint8Array`, for visualizers                                                                                 |
-| `startAudio()`                                         | Unlock playback under browser autoplay policies; call inside a user gesture (for example the click that starts the call) |
+| Method / property                                      | Description                                                                                                                                                                                                             |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setMicMuted(muted)` / `micMuted`                      | Mute or unmute the microphone. After a `microphone: false` start, the first unmute captures the microphone (permission prompt, so call it from a user gesture) and rejects with `mic_permission_denied` if refused |
+| `setOutputVolume(v)`                                   | Set playback volume, `0`–`1`                                                                                                                                                                                            |
+| `getInputVolume()` / `getOutputVolume()`               | Current mic / agent volume, `0`–`1`; poll per frame                                                                                                                                                                    |
+| `getInputFrequencyData()` / `getOutputFrequencyData()` | FFT data as `Uint8Array`, for visualizers                                                                                                                                                                               |
+| `startAudio()`                                         | Unlock playback under browser autoplay policies; call inside a user gesture (for example the click that starts the call)                                                                                               |
+| `setInputDevice(deviceId)`                             | Switch the microphone mid-call. Rejects with `device_change_failed` if the device cannot be activated, switching back to the previous microphone (best effort)                                                          |
+| `setOutputDevice(deviceId)`                            | Route playback to another output device (`""` for the default). Rejects with `device_change_failed` where the browser does not support output selection (common on mobile); playback stays on the previous device |
 
-Select specific devices at start with the `audio` option (`inputDeviceId` / `outputDeviceId`).
+Device ids come from `navigator.mediaDevices.enumerateDevices()`. To pick devices before the call starts, pass the `audio` option (`inputDeviceId` / `outputDeviceId`) to `start()` instead.
 
 ```javascript Audio visualizer
 function draw() {
@@ -215,7 +248,7 @@ const session = await AgentSession.start({
 session.registerClientTool("highlight_product", handler);
 ```
 
-Handlers can be sync or async; a thrown error or a timeout (default 15 s) is returned to the agent as a tool error. See [Client tools](/agents/build/client-tools) for declaration, naming rules, and dispatch semantics.
+Handlers can be sync or async; a thrown error or a timeout (default 15 s, set with `clientToolTimeoutMs`) is returned to the agent as a tool error. See [Client tools](/agents/build/client-tools) for declaration, naming rules, result size, and dispatch semantics.
 
 ## Errors
 
@@ -229,10 +262,10 @@ Failures surface as `FishAgentError`: thrown from `AgentSession.start()` when th
 | `unsupported_transport`             | The session token uses a transport this SDK version doesn't know; upgrade the SDK                                                                                                                                                             |
 | `mic_permission_denied`             | The user denied microphone access; the SDK ends the session                                                                                                                                                                                    |
 | `device_change_failed`              | A requested audio device could not be activated, or the browser doesn't support selecting it (output selection is unsupported on some mobile browsers). Thrown from `start()` with `audio.outputDeviceId` set, or from device-switching calls |
-| `connection_failed`                 | Could not establish the realtime connection                                                                                                                                                                                                    |
+| `connection_failed`                 | The realtime connection could not be established or recovered, a message to the agent could not be sent, the agent never joined (15 s), or the microphone could not be toggled                                                                |
 | `session_expired`                   | The session token's join deadline passed before connecting                                                                                                                                                                                     |
-| `tool_failed` / `tool_timeout`      | A client tool handler threw or timed out                                                                                                                                                                                                       |
-| `provider_error` / `internal_error` | The session failed server-side: upstream model/voice provider vs. platform runtime                                                                                                                                                            |
+| `tool_failed` / `tool_timeout`      | A client tool handler threw, was not registered, or its result could not be delivered / a handler exceeded `clientToolTimeoutMs`                                                                                                              |
+| `provider_error` / `internal_error` | The session failed server-side: upstream model/voice provider vs. platform runtime. Emitted on `error`; the session may recover                                                                                                                |
 
 <Note>
   `provider_error` and `internal_error` carry only the category code. Raw
@@ -240,12 +273,17 @@ Failures surface as `FishAgentError`: thrown from `AgentSession.start()` when th
 </Note>
 
 ```javascript Handle errors
+import { AgentSession, FishAgentError } from "@fishaudio/agent-client";
+
 try {
   const session = await AgentSession.start({ agentId: "YOUR_AGENT_ID" });
   session.on("error", err => console.warn("session error:", err.code));
 } catch (err) {
-  if (err.code === "agent_not_public") showEnableHint();
-  else showRetry(err.code);
+  if (err instanceof FishAgentError && err.code === "mic_permission_denied") {
+    showMicHelp();
+  } else {
+    showRetry(err);
+  }
 }
 ```
 
@@ -254,6 +292,12 @@ try {
 ```javascript Hang up
 await session.end(); // graceful hangup; disconnect fires with reason "user_hangup"
 ```
+
+`end()` is idempotent, including concurrent calls while teardown is still in flight, and `endReason` stays readable on the ended session.
+
+## Underlying connection
+
+The session API is transport-neutral: the server picks the transport when it creates the session, `livekit` (WebRTC) today. For needs the session API does not cover yet, such as connection-quality telemetry, `session.getRoom()` returns the live [livekit-client `Room`](https://docs.livekit.io/reference/client-sdk-js/), or `undefined` once the session has ended. Prefer the session API where one exists: code built on the `Room` couples to this SDK's transport choice and its pinned livekit-client major, with no compatibility promise across SDK versions. See [Wire protocol](/agents/deploy/protocol) for the messages underneath.
 
 ## Going further
 

--- a/agents/deploy/web-sdk.mdx
+++ b/agents/deploy/web-sdk.mdx
@@ -110,7 +110,7 @@ When the session ends, `disconnect` fires with a reason (also available as `sess
 | `agent_hangup`    | The server ended the session: the agent hung up (for example via the hang-up [system tool](/agents/build/system-tools)), the session hit its maximum duration, or it was force-ended; the protocol does not distinguish these |
 | `connection_lost` | The connection dropped and could not be recovered, or the agent never joined                                                                                                                                                   |
 
-Brief network drops don't end the session: the SDK moves to `reconnecting` and back to `connected` automatically, reusing the same session. It never creates a new session, so you never need a fresh token mid-call.
+Brief network drops don't end the session: the SDK moves to `reconnecting` and back to `connected` automatically, reusing the same session. It never creates a new session, so you never need a new token mid-call.
 
 <Warning>
   Events are not replayed after a reconnect. Anything emitted while you were in
@@ -293,7 +293,7 @@ try {
 await session.end(); // graceful hangup; disconnect fires with reason "user_hangup"
 ```
 
-`end()` is idempotent, including concurrent calls while teardown is still in flight, and `endReason` stays readable on the ended session.
+Calling `end()` more than once, or while a previous call is still finishing, is safe. `endReason` stays readable on the ended session.
 
 ## Underlying connection
 


### PR DESCRIPTION
Brings the two SDK pages up to the full public API of `@fishaudio/agent-client` 0.2 and `@fishaudio/agent-react` 0.2.

**Web SDK**
- Options table now covers every `start()` option (`serverUrl`, `clientToolTimeoutMs`, `endUserId`, `metadata`, `microphone`, `wakeLock`), gives `language` its exact union type, and shows the `callbacks` shorthand with an example.
- Lifecycle: agent join timeout, reconnection, idempotent `end()`, session properties.
- Transcript backfill with `getTranscript()`, tool call lifecycle, held text messages before the agent joins.
- Audio controls: `setInputDevice`, `setOutputDevice`, text-first (`microphone: false`) starts.
- `getRoom()` escape hatch and refined error meanings.

**React SDK**
- Next.js guidance (`"use client"`, Route Handler for session tokens).
- `useConversation(defaults)` merging, the full returned value, and lifecycle guarantees (double start, hangup during start, failure reset, unmount).
- Provider `options`, `useOptionalAgentSessionContext`, session resolution rules.
- `useAgentMessages` fields and streaming semantics, `useAudioLevels`, and `<AgentAudioVisualizer />` props.

Internal links and anchors checked; `mint broken-links` output unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791187868&installation_model_id=430858&pr_number=162&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F162&signature=991a7dff5ca951dddddb6f87c9d7034b33ffee6363ea9ec917716d121386820a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->