### PR TITLE
docs(agents): document attaching knowledge sources over the config API

### DIFF
--- a/agents/build/knowledge-base.mdx
+++ b/agents/build/knowledge-base.mdx
@@ -107,7 +107,7 @@ Only the `source` file part is required on create: `name` falls back to the uplo
 
 ### Attach sources to an agent
 
-Attach sources through the agent's configuration. `knowledge_source_ids` replaces the attached list as a whole, and attaching a non-empty list turns retrieval on unless you send `enabled: false` alongside it, which keeps the sources attached but unused until you enable them later. Publish for the change to reach live sessions.
+Attach sources through the agent's configuration. `knowledge_source_ids` replaces the whole attached list. Attaching sources also turns the knowledge base on, unless you send `enabled: false` with them to attach now and switch on later. Publish for the change to reach live sessions.
 
 ```bash Attach sources
 curl --request PATCH https://api.fish.audio/v1/agent/agents/YOUR_AGENT_ID/config \
@@ -122,8 +122,8 @@ curl --request PATCH https://api.fish.audio/v1/agent/agents/YOUR_AGENT_ID/config
 
 | Field                  | Rules                                                                                                                                                             |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `knowledge_source_ids` | Workspace source ids, up to 100. Replaces the attached list wholesale; an unknown id is rejected with `422`. Send `[]` to detach everything                       |
-| `enabled`              | Whether the agent retrieves from the attached sources. Defaults to `true` when omitted with a non-empty `knowledge_source_ids`; send `false` to stage sources without using them |
+| `knowledge_source_ids` | Workspace source ids, up to 100. Replaces the whole attached list; an unknown id is rejected with `422`. Send `[]` to detach everything                       |
+| `enabled`              | Whether the agent uses the attached sources. Defaults to `true` when omitted together with a non-empty `knowledge_source_ids`; send `false` to attach sources without using them yet |
 
 <Note>
 `DELETE` returns `409` while the source is still attached to any agent, in its draft or its published version. Call the dependents endpoint to see which agents use it, then detach it from each (remove its id from `knowledge_base.knowledge_source_ids` in an agent update) and republish any agent whose published version still references it. Deleting from the console instead removes the source from all agents at once, after a confirmation.

--- a/agents/build/knowledge-base.mdx
+++ b/agents/build/knowledge-base.mdx
@@ -105,6 +105,26 @@ curl https://api.fish.audio/v1/agent/knowledge-sources/{source_id}/agents \
 
 Only the `source` file part is required on create: `name` falls back to the uploaded file's name.
 
+### Attach sources to an agent
+
+Attach sources through the agent's configuration. `knowledge_source_ids` replaces the attached list as a whole, and attaching a non-empty list turns retrieval on unless you send `enabled: false` alongside it, which keeps the sources attached but unused until you enable them later. Publish for the change to reach live sessions.
+
+```bash Attach sources
+curl --request PATCH https://api.fish.audio/v1/agent/agents/YOUR_AGENT_ID/config \
+  --header "Authorization: Bearer $FISH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "knowledge_base": {
+      "knowledge_source_ids": ["SOURCE_ID_1", "SOURCE_ID_2"]
+    }
+  }'
+```
+
+| Field                  | Rules                                                                                                                                                             |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `knowledge_source_ids` | Workspace source ids, up to 100. Replaces the attached list wholesale; an unknown id is rejected with `422`. Send `[]` to detach everything                       |
+| `enabled`              | Whether the agent retrieves from the attached sources. Defaults to `true` when omitted with a non-empty `knowledge_source_ids`; send `false` to stage sources without using them |
+
 <Note>
 `DELETE` returns `409` while the source is still attached to any agent, in its draft or its published version. Call the dependents endpoint to see which agents use it, then detach it from each (remove its id from `knowledge_base.knowledge_source_ids` in an agent update) and republish any agent whose published version still references it. Deleting from the console instead removes the source from all agents at once, after a confirmation.
 </Note>


### PR DESCRIPTION
Adds an "Attach sources to an agent" subsection to the knowledge base page: the `PATCH .../config` request, and the rules for `knowledge_source_ids` and `enabled`. Attaching a non-empty list enables retrieval unless `enabled: false` is sent explicitly, matching platform-api PR fishaudio/platform-api#1586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791187935&installation_model_id=430858&pr_number=163&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F163&signature=00e5fe3bbdc99b6290d8bfebf8a5a86148e4fc86cf33a24219bb5fe05aafbbe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->