### PR TITLE
docs(agents): webhook secrets are kept when an update omits them

### DIFF
--- a/agents/monitor/webhooks.mdx
+++ b/agents/monitor/webhooks.mdx
@@ -74,13 +74,13 @@ httpx.patch(
 
 </CodeGroup>
 
-The list is replaced as a whole on each update, so send every endpoint you want to keep. Set it to `null` or `[]` to stop deliveries. A single `post_call` object is still accepted and is treated as a one-element list.
+The list is replaced as a whole on each update, so send every endpoint you want to keep. Set it to `null` or `[]` to stop deliveries. A single `post_call` object is still accepted and is treated as a one-element list. Secrets are write-only, so an entry sent without a `secret` keeps the secret already stored for that `url`; you can read the configuration, edit the list, and send it back without re-entering secrets.
 
 | Field       | Rules                                                                                                                                                                                       |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `post_call` | Up to 5 entries, and their `url` values must be unique. A longer list or a repeated URL is rejected with `422`                                                                             |
 | `url`       | Required on every entry. Up to 4000 characters. Must resolve to a public address. Localhost and private-network hosts are rejected with `422`, and the check is repeated at every delivery |
-| `secret`    | Optional signing key, up to 256 characters, set per entry. **Write-only**: reads return `has_secret: true`, never the value                                                                 |
+| `secret`    | Optional signing key, up to 256 characters, set per entry. **Write-only**: reads return `has_secret: true`, never the value. Omit it (or send `null`) to keep the stored secret for the same `url`; send `""` to remove it |
 
 <Note>
   Webhook settings are part of the agent configuration, so they follow the

--- a/api-reference/agent-errors.mdx
+++ b/api-reference/agent-errors.mdx
@@ -51,7 +51,7 @@ The exceptions to that shape:
 
 Two quirks worth coding around:
 
-- **Explicit `null` is rejected** on `PATCH` endpoints with `422`: omit a field to keep its value, send `""` to clear a text field.
+- **Explicit `null` is rejected** on most `PATCH` fields with `422`: omit a field to keep its value, send `""` to clear a text field. Write-only secrets (`llm.custom.api_key`, webhook `secret`) treat `null` like omission and keep the stored value.
 - **Path-parameter validation renders `404`, not `422`**: a non-integer `{version_number}` looks like a missing version.
 
 ## 403: what was refused


### PR DESCRIPTION
Documents the round-trip rule for write-only webhook secrets on the config API: an entry sent without a `secret` (or with `null`) keeps the stored secret for the same `url`, and `""` removes it. Also notes on the errors page that write-only secrets treat `null` like omission. Matches platform-api PR fishaudio/platform-api#1587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791187940&installation_model_id=430858&pr_number=164&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F164&signature=5fb20454c54a32163d9ddbfb5a6744ab8d7c0ec02d587c8e845e6b26a7764904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->