### PR TITLE
docs(agents): add a pricing page

### DIFF
--- a/agents/deploy/public-agents.mdx
+++ b/agents/deploy/public-agents.mdx
@@ -82,7 +82,7 @@ http://127.0.0.1:5173
 
 ## Rate limiting
 
-Public session creation is rate limited on two dimensions at once: per **client IP** and per **agent**. Either limit being exceeded rejects the request. Sessions started on a public agent are billed to the workspace that owns the agent.
+Public session creation is rate limited on two dimensions at once: per **client IP** and per **agent**. Either limit being exceeded rejects the request. Sessions started on a public agent are billed to the workspace that owns the agent, at the standard [conversation rate](/agents/pricing).
 
 <Note>
   If legitimate traffic outgrows these limits, or you need per-user quotas, move

--- a/agents/pricing.mdx
+++ b/agents/pricing.mdx
@@ -15,10 +15,10 @@ Agents bill by the second of conversation, with a small number of add-ons for te
 | Phone call surcharge                   | +$0.01 per minute   | Added to the conversation rate on inbound calls and on outbound calls to the US and Canada                                                                 |
 | Outbound to Japan                      | +$0.25 or +$0.10 per minute | Mobile numbers +$0.25, landline and 050 numbers +$0.10, instead of the standard phone surcharge                                                    |
 | Phone number rental                    | $1.20 per month     | Charged in daily slices while you hold the number; stops when you release it                                                                              |
-| Cold transfer leg                      | $0.015 per minute   | Metered from the handoff; the conversation rate stops at that point                                                                                       |
-| Warm transfer leg                      | $0.025 per minute   | Metered from the merge, with recording and transcription of the joined call                                                                               |
+| Cold transfer                          | $0.015 per minute   | Charged for the time after the agent hands the call to a person; the conversation rate stops at that point                                                 |
+| Warm transfer                          | $0.025 per minute   | Charged for the time after the caller and the person are joined; the joined call is still recorded and transcribed                                       |
 
-Rates are per minute for readability; metering is per second. Only the phone surcharge, number rental, and transfer legs apply to [imported SIP numbers](/agents/telephony/byo-sip): calls on them bill as conversation minutes only, with no telephony charges at all.
+Rates are shown per minute; usage is counted per second. [Imported SIP numbers](/agents/telephony/byo-sip) skip the phone surcharge, number rental, and transfer charges: calls on them bill as conversation minutes only.
 
 ### Models
 
@@ -36,18 +36,18 @@ The surcharge follows the configured model for the whole session. A [custom LLM]
 
 Every account starts with **60 free minutes** of agent conversation. They apply to real usage, so you can take the whole product for a spin before adding credit:
 
-- Web sessions, phone calls, and transfer legs all draw on the same pool, second for second.
+- Web sessions, phone calls, and transferred call time all draw on the same pool, second for second.
 - Number rental draws on it too, at one minute per day of rental, so you can get a number and test inbound calls without a balance.
 - Sessions on a premium model are the exception: they need a paid balance, because the free pool covers only the included models.
 - [Preview calls](/agents/test/preview-calls) in the Builder are free and never count against the pool.
 
 ## Billing
 
-Usage is charged to your **API credit**, the same prepaid balance that pays for the Fish Audio speech APIs. Each session is settled when it ends: its billable seconds times the applicable rates, after the free pool is exhausted. Number rental is charged daily from the same balance.
+Usage is charged to your **API credit**, the same prepaid balance that pays for the Fish Audio speech APIs. Each session is charged when it ends: its seconds times the rates above, once the free minutes are used up. Number rental is charged daily from the same balance.
 
 When the balance runs out, new sessions and inbound calls are refused until you top up. Session creation returns `402`, and the same status appears on [outbound call](/agents/telephony/outbound-calls#errors) requests.
 
-Every charge is itemized on the [Agents billing page](https://fish.audio/app/agents/billing): one record per component (conversation minutes, phone surcharge, transfer legs, number rental), with the rate applied and the free minutes used. The current price list is shown at the bottom of that page.
+Every charge is itemized on the [Agents billing page](https://fish.audio/app/agents/billing): one record per item (conversation minutes, phone surcharge, transfers, number rental), with the rate applied and the free minutes used. The current price list is shown at the bottom of that page.
 
 ## Going further
 

--- a/agents/pricing.mdx
+++ b/agents/pricing.mdx
@@ -1,0 +1,71 @@
+---
+title: "Pricing"
+description: "What agent conversations, phone calls, numbers, and transfers cost, and how the free minutes and API credit work"
+icon: "credit-card"
+---
+
+Agents bill by the second of conversation, with a small number of add-ons for telephony and premium models. Every account starts with free minutes, and everything after that is charged against your API credit.
+
+## Rates
+
+| Item                                   | Price               | Notes                                                                                                                                                     |
+| -------------------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Agent conversation                     | $0.06 per minute    | Billed per second. Includes speech recognition, the default model tier, speech synthesis, knowledge base retrieval, and tool calls                       |
+| Premium model surcharge                | +$0.05 or +$0.10 per minute | Added while the agent runs a model from a higher tier; see [Models](#models). Custom LLM endpoints carry no surcharge                              |
+| Phone call surcharge                   | +$0.01 per minute   | Added to the conversation rate on inbound calls and on outbound calls to the US and Canada                                                                 |
+| Outbound to Japan                      | +$0.25 or +$0.10 per minute | Mobile numbers +$0.25, landline and 050 numbers +$0.10, instead of the standard phone surcharge                                                    |
+| Phone number rental                    | $1.20 per month     | Charged in daily slices while you hold the number; stops when you release it                                                                              |
+| Cold transfer leg                      | $0.015 per minute   | Metered from the handoff; the conversation rate stops at that point                                                                                       |
+| Warm transfer leg                      | $0.025 per minute   | Metered from the merge, with recording and transcription of the joined call                                                                               |
+
+Rates are per minute for readability; metering is per second. Only the phone surcharge, number rental, and transfer legs apply to [imported SIP numbers](/agents/telephony/byo-sip): calls on them bill as conversation minutes only, with no telephony charges at all.
+
+### Models
+
+The model your agent runs is chosen in the Builder, and each option shows its surcharge next to its name:
+
+| Surcharge                | Models                                                                      |
+| ------------------------ | --------------------------------------------------------------------------- |
+| Included                 | Gemini 3.5 Flash Lite (default), GPT-5.6 Luna, Gemma 4 26B, Qwen 3.5 122B  |
+| +$0.05 per minute        | Gemini 3.6 Flash, Claude Haiku 4.5                                          |
+| +$0.10 per minute        | Claude Sonnet 4.6, GPT-4o                                                   |
+
+The surcharge follows the configured model for the whole session. A [custom LLM](/agents/build/custom-llm) endpoint is billed at the base conversation rate.
+
+## Free minutes
+
+Every account starts with **60 free minutes** of agent conversation. They apply to real usage, so you can take the whole product for a spin before adding credit:
+
+- Web sessions, phone calls, and transfer legs all draw on the same pool, second for second.
+- Number rental draws on it too, at one minute per day of rental, so you can get a number and test inbound calls without a balance.
+- Sessions on a premium model are the exception: they need a paid balance, because the free pool covers only the included models.
+- [Preview calls](/agents/test/preview-calls) in the Builder are free and never count against the pool.
+
+## Billing
+
+Usage is charged to your **API credit**, the same prepaid balance that pays for the Fish Audio speech APIs. Each session is settled when it ends: its billable seconds times the applicable rates, after the free pool is exhausted. Number rental is charged daily from the same balance.
+
+When the balance runs out, new sessions and inbound calls are refused until you top up. Session creation returns `402`, and the same status appears on [outbound call](/agents/telephony/outbound-calls#errors) requests.
+
+Every charge is itemized on the [Agents billing page](https://fish.audio/app/agents/billing): one record per component (conversation minutes, phone surcharge, transfer legs, number rental), with the rate applied and the free minutes used. The current price list is shown at the bottom of that page.
+
+## Going further
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/agents/quickstart">
+    Create an agent and talk to it within the free minutes.
+  </Card>
+  <Card
+    title="Phone numbers"
+    icon="hashtag"
+    href="/agents/telephony/phone-numbers"
+  >
+    Buy or import a number and bind it to an agent.
+  </Card>
+  <Card title="Transfers" icon="phone-arrow-right" href="/agents/telephony/transfers">
+    Cold and warm transfers to a human.
+  </Card>
+  <Card title="Custom LLM" icon="brain" href="/agents/build/custom-llm">
+    Run your own model endpoint at the base rate.
+  </Card>
+</CardGroup>

--- a/agents/telephony/byo-sip.mdx
+++ b/agents/telephony/byo-sip.mdx
@@ -169,7 +169,7 @@ Updates apply in place: routing is never interrupted, and calls already in progr
 
 ## Billing
 
-Imported numbers are free on Fish Audio: no monthly rental, no phone surcharge, no transfer fees. Calls on them bill as agent minutes only, like web sessions. Your carrier continues to bill you directly for its side of the traffic.
+Imported numbers are free on Fish Audio: no monthly rental, no phone surcharge, no transfer fees. Calls on them bill as agent minutes only, like web sessions (see [Pricing](/agents/pricing)). Your carrier continues to bill you directly for its side of the traffic.
 
 ## Release
 

--- a/agents/telephony/phone-numbers.mdx
+++ b/agents/telephony/phone-numbers.mdx
@@ -44,7 +44,7 @@ curl --request POST https://api.fish.audio/v1/agent/phone-numbers \
   }'
 ```
 
-Returns `201` with the number object, the same shape the list endpoint returns. The number lands in your default workspace, and its monthly price is billed in daily slices.
+Returns `201` with the number object, the same shape the list endpoint returns. The number lands in your default workspace, and its monthly price is billed in daily slices; see [Pricing](/agents/pricing).
 
 | Field          | Description                                                             |
 | -------------- | ----------------------------------------------------------------------- |

--- a/agents/telephony/transfers.mdx
+++ b/agents/telephony/transfers.mdx
@@ -120,7 +120,7 @@ If the human cannot be reached, declines, or the consult call hits voicemail, th
 
 ## Billing
 
-Transferred call time is metered separately from agent time, with cold and warm transfers each billed at their own per-minute rate. The standard agent rate stops at the handoff for cold transfers and at the merge for warm transfers; from that point the call is metered as transfer minutes.
+Transferred call time is metered separately from agent time, with cold and warm transfers each billed at their own per-minute rate. The standard agent rate stops at the handoff for cold transfers and at the merge for warm transfers; from that point the call is metered as transfer minutes. Current rates are on the [Pricing](/agents/pricing) page.
 
 ## Going further
 

--- a/agents/telephony/transfers.mdx
+++ b/agents/telephony/transfers.mdx
@@ -120,7 +120,7 @@ If the human cannot be reached, declines, or the consult call hits voicemail, th
 
 ## Billing
 
-Transferred call time is metered separately from agent time, with cold and warm transfers each billed at their own per-minute rate. The standard agent rate stops at the handoff for cold transfers and at the merge for warm transfers; from that point the call is metered as transfer minutes. Current rates are on the [Pricing](/agents/pricing) page.
+Time after a transfer is billed separately from agent time, at a cold or warm transfer rate per minute. The agent rate stops when the call is handed over (cold) or when the caller and the person are joined (warm); from that point the call is billed as transfer minutes. Current rates are on the [Pricing](/agents/pricing) page.
 
 ## Going further
 

--- a/docs.json
+++ b/docs.json
@@ -73,7 +73,12 @@
         "groups": [
           {
             "group": "Get Started",
-            "pages": ["agents/overview", "agents/quickstart", "agents/concepts"]
+            "pages": [
+              "agents/overview",
+              "agents/quickstart",
+              "agents/concepts",
+              "agents/pricing"
+            ]
           },
           {
             "group": "Build",


### PR DESCRIPTION
Adds `agents/pricing` under Get Started: per-minute rates (conversation, premium model surcharges, phone surcharge, Japan outbound, number rental, transfer legs), the model tiers, the 60 free minutes and what they cover, and how API credit billing and the billing page work. Telephony pages and the public agents page link to it.

Numbers and model names come from the current price list in the console's billing page. Please review them before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791188108&installation_model_id=430858&pr_number=167&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F167&signature=f5dbafba65db5c49f601f0929618a3d8743a98f5f01a9f964832542ea4dcd497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->