### PR TITLE
Self-hosting docs: platforms and modes, and today's dashboard

### DIFF
--- a/developer-guide/self-hosting/air-gapped.mdx
+++ b/developer-guide/self-hosting/air-gapped.mdx
@@ -4,7 +4,7 @@ description: "Running Fish Audio Enterprise on a network that cannot reach Fish 
 icon: "shield-halved"
 ---
 
-Both offline delivery forms make no outbound calls at runtime. Neither one, however,
+Both offline modes make no outbound calls at runtime. Neither one, however,
 installs itself out of thin air: a Helm install pulls container images and the chart
 from a registry, and the appliance needs its image on the host. An air-gapped
 deployment is about getting those artifacts across the boundary. The license bundle
@@ -18,12 +18,12 @@ a one-off.
   expect and what to plan for.
 </Note>
 
-## Which form to choose
+## Which one to choose
 
 **The air-gapped All-in-One appliance** is the straightforward answer to a strict air
-gap: one image with every weight baked in, moved to the disconnected host as a file and
-loaded there. There is nothing else to mirror, though the license bundle still has to
-be carried across. Its online counterpart cannot run air
+gap: one image, moved to the disconnected host as a file and loaded there. Beyond the
+image, only the license bundle — and, in the external-weights modes, the weight
+fileset — has to be carried across. Its online counterpart cannot run air
 gapped: it authorises every request against Fish Audio.
 
 **The Helm chart** is more work, because the release is many images rather than one.
@@ -63,5 +63,5 @@ complete it.
 ## Next steps
 
 - [Requirements](/developer-guide/self-hosting/requirements): hardware, platform, and network baselines
-- [All-in-One container](/developer-guide/self-hosting/all-in-one): the single-container form
-- [Kubernetes deployment](/developer-guide/self-hosting/kubernetes): the Helm forms
+- [All-in-One container](/developer-guide/self-hosting/all-in-one): the single-container platform
+- [Kubernetes deployment](/developer-guide/self-hosting/kubernetes): the Helm platform

--- a/developer-guide/self-hosting/all-in-one.mdx
+++ b/developer-guide/self-hosting/all-in-one.mdx
@@ -6,11 +6,11 @@ icon: "box"
 
 The All-in-One image packages the whole speech stack (edge API, model API layer,
 inference router and worker, vocoder, text normalizer, and Redis) into one container,
-with every model weight baked in. It runs as a turnkey single-node appliance, no Kubernetes.
+with the model weights baked into the image, except in the external-weights modes. It runs as a turnkey single-node appliance, no Kubernetes.
 
-The two forms, **Offline All-in-One** and **Online All-in-One**, differ only in how
-usage is accounted for. The offline form records usage to a local
-ledger and needs no network once the image is on the host. The online form authorises
+The two billing modes, **Offline All-in-One** and **Online All-in-One**, differ only in how
+usage is accounted for. The offline mode records usage to a local
+ledger and needs no network once the image is on the host. The online mode authorises
 each request against Fish Audio and charges the key that made it, so it needs outbound
 access and a key with credit. The accounting is compiled in, so an image is one or the
 other; the container logs which at startup.
@@ -24,7 +24,8 @@ other; the container logs which at startup.
 
 ## What it cannot do
 
-The appliance runs one inference worker and one vocoder, a GPU each. It does not
+The appliance runs one inference worker and one vocoder — a GPU each, or one
+shared 80 GB-class card in the Single-GPU mode. It does not
 autoscale, does not shard across more GPUs or nodes, and does not ship the forced
 aligner, so it returns no word or segment timings. For elastic or higher-throughput
 deployments, use the [Kubernetes chart](/developer-guide/self-hosting/kubernetes), which
@@ -36,11 +37,13 @@ One `docker run` on a host that meets the
 [All-in-One host requirements](/developer-guide/self-hosting/requirements#all-in-one-container-host).
 It needs:
 
-- **Two GPUs.** The first runs the inference worker, the second the vocoder.
+- **One or two GPUs.** The Dual-GPU modes give the inference worker and the vocoder
+  a card each; the Single-GPU mode runs both on one 80 GB-class card.
 - **One exposed port** for the API.
 - **One persistent volume.** Compile caches, the vocoder's built engine, reference
-  voice archives, and — on the offline form — the usage ledger all live there. Model
-  weights are in the image, not on the volume.
+  voice archives, and — in the offline mode — the usage ledger all live there. Model
+  weights are in the image, not on the volume; the external-weights modes mount
+  them at run time instead — the delivered guide covers that mount.
 - **The license bundle.** A host directory holding the certificate and key pair from
   **Developer → Self Host**, mounted read-only. Without it the API never comes up; once
   the certificate expires the container starts but refuses requests. Renewing is
@@ -58,7 +61,7 @@ the GPU model, so moving to different cards rebuilds it once.
 
 ## Usage accounting and tenancy
 
-The form determines how usage is accounted for and what the bearer token has to be.
+The billing mode determines how usage is accounted for and what the bearer token has to be.
 
 **Offline.** Usage goes to a local, signed, append-only ledger on the volume. Two
 consequences worth designing around:

--- a/developer-guide/self-hosting/enterprise-releases.mdx
+++ b/developer-guide/self-hosting/enterprise-releases.mdx
@@ -4,26 +4,28 @@ description: "How Fish Audio Enterprise versions are identified and how to move 
 icon: "code-branch"
 ---
 
-Fish Audio publishes a version of each delivery form once it has been tested.
+Fish Audio publishes a version for each mode once it has been tested.
 **Developer → Self Host** lists the versions available to your team and fills the
 one you pick into the install commands on that page.
 
 ## Version identifiers
 
-| Delivery form                | Identified by   | Applied with                         |
-| ---------------------------- | --------------- | ------------------------------------ |
-| Online Helm and Offline Helm | A chart version | `--version` on `helm pull`/`install` |
-| All-in-One                   | An image tag    | The tag in the image reference       |
+| Platform    | Identified by   | Applied with                         |
+| ----------- | --------------- | ------------------------------------ |
+| Helm        | A chart version | `--version` on `helm pull`/`install` |
+| All-in-One  | An image tag    | The tag in the image reference       |
 
-Both Helm forms are one chart, so they share a version. Which form you deploy is
-decided by the values file, not by the version. The two All-in-One forms are separate
-images with independent tags.
+Both Helm profiles are one chart, so they share a version. Which profile you deploy is
+decided by the values file, not by the version. Each All-in-One mode — the
+combination of billing, GPU topology, and how weights are delivered — is released
+and tagged independently; **Developer → Self Host** shows the ones your team
+is granted.
 
 ## Upgrading
 
 A deployment stays on its version until you change it. Take the new version from
 **Developer → Self Host**, then follow the upgrade
-procedure in the deployment runbook for the Helm forms, or pull the new tag and
+procedure in the deployment runbook for the Helm platform, or pull the new tag and
 recreate the container against the same volume for
 [All-in-One](/developer-guide/self-hosting/all-in-one). Air-gapped deployments
 mirror the new version first. See

--- a/developer-guide/self-hosting/introduction.mdx
+++ b/developer-guide/self-hosting/introduction.mdx
@@ -18,32 +18,46 @@ audio formats, and voice behavior match what you already build against.
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | Colocation              | Run inference in the same region, VPC, or rack as your application and remove public-internet round trips from time-to-first-audio.     |
 | Single-tenant isolation | Dedicated GPUs and queues. Capacity is not shared with other tenants, and you decide when the deployment is upgraded.                   |
-| Security posture        | Voice traffic never leaves your network. The offline delivery forms make no outbound calls at runtime and run on disconnected networks. |
+| Security posture        | Voice traffic never leaves your network. The offline modes make no outbound calls at runtime and run on disconnected networks. |
 | Data sovereignty        | Input text, generated audio, and reference voices stay inside your boundary and under your own retention policy.                        |
 
-## Delivery forms
+## Platforms and modes
 
-The same engine ships in four forms. Your enterprise agreement determines which
-ones your team is granted.
+The same engine ships on two platforms. Your enterprise agreement determines
+which platforms — and which modes of each — your team is granted.
 
-|                  | Online Helm                                         | Offline Helm                                     | Offline All-in-One                                  | Online All-in-One                                |
-| ---------------- | --------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------- | ------------------------------------------------ |
-| Platform         | Kubernetes                                          | Kubernetes                                       | A single container, `docker run`                    | A single container, `docker run`                 |
-| Model assets     | Served in-cluster from a bundled model warehouse    | Same                                             | Baked into the image                                | Baked into the image                             |
-| Usage accounting | Validated and billed against the Fish Audio service | Local signed usage ledger                        | Local signed usage ledger                           | Validated and billed against the Fish Audio service |
-| Runtime egress   | The billing endpoint, plus one more host if you enable timestamps | None                                             | None                                                | The billing endpoint                             |
-| Air-gap capable  | No                                                  | Yes, after mirroring images and charts           | Yes                                                 | No                                               |
-| Scaling          | Scales replicas across all GPUs and nodes           | Same                                             | Single node, single inference worker                | Single node, single inference worker             |
-| Best for         | Managed clusters with outbound access               | Isolated or regulated production clusters        | Evaluation, single-node appliances, strict air gaps | Single-node appliances billed like the hosted service |
+|          | Helm (Kubernetes)                                                              | All-in-One (Docker)                                    |
+| -------- | ------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| Shape    | The chart on your cluster: replicas across GPUs and nodes, rolling upgrades.   | One container on one GPU host; the smallest footprint. |
+| Best for | Production clusters and elastic capacity.                                       | Evaluation, fixed-size appliances, strict air gaps.    |
 
-Both Helm forms share one deployment procedure and differ only in a few values.
+A **mode** is a combination of the axes below; on Helm only billing is a mode —
+the other axes are cluster configuration. **Developer → Self Host** shows the
+modes your team can install.
+
+**Online** billing authorizes and bills each request against Fish Audio and
+needs outbound access; **Offline** records usage to a local signed ledger and
+runs air-gapped.
+
+| Axis     | All-in-One                                                                                          | Helm                                                                                                                |
+| -------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Billing  | Online or Offline.                                                                                  | The same two, as deployment profiles of one chart — a values file selects the profile.                               |
+| Topology | **Dual-GPU** — worker and vocoder on a card each. **Single-GPU** — both share one 80 GB-class card. | Not a mode — each component takes a whole GPU; you add replicas to grow.                                             |
+| Weights  | **Baked** into the image, or **external** — mounted at run time.                                    | In-cluster by default; the online profile can instead pull from S3-compatible storage — see [Kubernetes deployment](/developer-guide/self-hosting/kubernetes). |
+
+The offline modes are air-gap capable — the Helm profile after mirroring images
+and the chart into your own registry.
+
+Combinations beyond this standard set can be discussed with your account team.
+
+Both Helm profiles share one deployment procedure and differ only in a few values.
 See [Kubernetes deployment](/developer-guide/self-hosting/kubernetes) for the
-Helm forms and [All-in-One container](/developer-guide/self-hosting/all-in-one)
-for the single-container form.
+Helm platform and [All-in-One container](/developer-guide/self-hosting/all-in-one)
+for the single-container platform.
 
 ## What is included
 
-| Capability                                | Online Helm                  | Offline Helm             | All-in-One (both forms)  |
+| Capability                                | Online Helm                  | Offline Helm             | All-in-One (all modes)  |
 | ----------------------------------------- | ---------------------------- | ------------------------ | ------------------------ |
 | Text to speech over `POST /v1/tts`        | Included                     | Included                 | Included                 |
 | WebSocket streaming                       | Included                     | Included                 | Included                 |
@@ -56,7 +70,7 @@ for the single-container form.
   Timestamp alignment is served by a separate forced-aligner component. It is
   disabled by default, is not part of the offline model bundle, and is not built
   into the All-in-One image, so `/v1/tts/stream/with-timestamp` returns audio
-  without alignment data on those forms. Contact Fish Audio if your deployment
+  without alignment data in those modes. Contact Fish Audio if your deployment
   needs timestamps.
 </Note>
 
@@ -66,6 +80,9 @@ on fish.audio are not automatically available to it. Products other than text to
 speech are hosted-only unless your agreement says otherwise.
 
 ## Architecture at a glance
+
+The table describes the Helm deployment; the All-in-One runs the same components
+inside one container.
 
 | Component          | Role                                                                                           |
 | ------------------ | ---------------------------------------------------------------------------------------------- |
@@ -96,9 +113,9 @@ configure.
     image where applicable.
   </Step>
   <Step title="Create a deploy token">
-    Sign in to fish.audio and open **Developer → Self Host** to see the delivery
-    forms your team is granted and to create the token that authenticates
-    against the registry. See [Registry
+    Sign in to fish.audio and open **Developer → Self Host** to see the
+    platforms and modes your team is granted and to create the token that
+    authenticates against the registry. See [Registry
     access](/developer-guide/self-hosting/registry-access).
   </Step>
 </Steps>

--- a/developer-guide/self-hosting/kubernetes.mdx
+++ b/developer-guide/self-hosting/kubernetes.mdx
@@ -5,7 +5,7 @@ icon: "dharmachakra"
 ---
 
 Fish Audio Enterprise ships as a Helm chart that installs the whole speech stack into
-a cluster you run. Both Helm delivery forms use the same chart and the same procedure;
+a cluster you run. Both Helm profiles use the same chart and the same procedure;
 they differ only in how usage is accounted.
 
 <Note>
@@ -16,23 +16,27 @@ they differ only in how usage is accounted.
   versioned with the chart; this page is not, so follow the runbook when they differ.
 </Note>
 
-## Choose a delivery form
+## Choose a billing profile
 
 |                  | Offline                                          | Online                                              |
 | ---------------- | ------------------------------------------------ | --------------------------------------------------- |
 | Usage accounting | Local signed ledger on shared storage            | Validated and billed against the Fish Audio service |
-| Runtime egress   | None                                             | The billing endpoint on 443                         |
-| Model assets     | Served in-cluster by the bundled model warehouse | The same                                            |
+| Runtime egress   | None                                             | The billing endpoint on 443 — plus the model-source endpoint, if you use one |
+| Model assets     | Served in-cluster by the bundled model warehouse | In-cluster by default; can instead pull from S3-compatible storage |
 
-Both forms serve model weights from inside the cluster, so neither reaches an external
-object store at runtime. "Offline" means runtime-offline: installation still pulls
+Both profiles serve model weights from inside the cluster by default. The online
+profile can point the workers at S3-compatible storage instead — Fish Audio's
+hosted bucket or your own; the deployment runbook's "Model source" section covers
+the how. The offline profile stays in-cluster, since it runs with no egress.
+"Offline" means runtime-offline: installation still pulls
 images and the chart from a registry. For a cluster with no network access at all, see
 [Air-gapped deployments](/developer-guide/self-hosting/air-gapped).
 
 ## What gets installed
 
 The chart deploys the edge API, the model API layer, an inference router and worker,
-a vocoder, a text normalizer, the model warehouse that serves the weights, and Redis.
+a vocoder, a text normalizer, the model warehouse that serves the weights when
+you use the default in-cluster model source, and Redis.
 Everything lands in one namespace, in the single-worker shape the delivery was sized
 against.
 
@@ -44,7 +48,7 @@ manage that layer.
 
 | Decision                    | Notes                                                                                                                     |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Namespace                   | `fish-audio` is the supported default. A different one has to be set in two places; the runbook says where. |
+| Namespace                   | `fish-audio` is the supported default. A different one only needs Helm's `--namespace` argument. |
 | Shared storage path         | Mounted at the same path on **every** node. See [Requirements](/developer-guide/self-hosting/requirements#shared-storage). |
 | GPU scheduling              | Tolerations and node selectors, if your GPU nodes are tainted or you run more than one GPU model.                          |
 | Metrics                     | The chart exposes Prometheus annotations and creates no ServiceMonitors, so an annotation-scraping Prometheus works as-is and kube-prometheus-stack needs a scrape config. |
@@ -53,7 +57,8 @@ manage that layer.
 
 Three Kubernetes Secrets have to exist before the install: registry credentials, the
 license bundle, and one shared between the in-cluster model store and the workers that
-read from it. The license bundle is the certificate and key pair downloaded from
+read from it (with an external model source, that secret instead carries the real
+access keys for the storage — the runbook covers it). The license bundle is the certificate and key pair downloaded from
 **Developer → Self Host**; the services that enforce it stay down until the Secret
 exists, and refuse requests once the certificate lapses — renewal is described in
 [Operations](/developer-guide/self-hosting/operations#license-renewal). The model-store

--- a/developer-guide/self-hosting/operations.mdx
+++ b/developer-guide/self-hosting/operations.mdx
@@ -4,7 +4,7 @@ description: "Monitoring, scaling, backups, and troubleshooting for a self-hoste
 icon: "chart-line"
 ---
 
-Day-2 guidance for the Kubernetes delivery forms. For the single-container form, see
+Day-2 guidance for the Helm platform. For the single-container platform, see
 [All-in-One container](/developer-guide/self-hosting/all-in-one).
 
 ## Ownership
@@ -74,7 +74,7 @@ Update the license Secret in place with the renewed bundle; no restart is needed
 Kubernetes propagates the change to the running pods, and each service re-verifies on
 its own short cycle, so expect up to a couple of minutes of mixed responses before
 it settles. One exception: a bundle
-that carries a new key rather than a re-signed certificate. The offline form's edge API
+that carries a new key rather than a re-signed certificate. The offline profile's edge API
 reads the ledger-signing key only at startup, so restart that deployment after
 replacing a key.
 

--- a/developer-guide/self-hosting/registry-access.mdx
+++ b/developer-guide/self-hosting/registry-access.mdx
@@ -10,18 +10,24 @@ dashboard.
 
 ## The Self Host page
 
-Sign in to fish.audio and open **Developer → Self Host**. Everything your team needs to
-start is there:
+Sign in to fish.audio and open **Developer → Self Host**. The page walks your team
+through four steps:
 
-- **Your deployment**: the delivery forms your team is granted. If it is empty, or the
-  page reports that self-host deployment is not enabled, contact your account manager.
-- **The versions available to you**, and the documentation bundle for each. See
-  [Releases](/developer-guide/self-hosting/enterprise-releases).
-- **Your license bundle**: the certificate and key the deployment needs before it will
-  serve. Some contracts bind it to specific GPUs — have the card UUIDs ready when you
-  request it.
-- **Install commands built for your team**, with the registry host, artifact references,
-  and the version you pick already filled in.
+1. **Choose your platform** — the platforms and modes your team is granted, and the
+   prerequisites to check first. If the page is empty, or reports that self-host
+   deployment is not enabled, contact your account manager.
+2. **Deploy token** — create the credential the install commands in step 4
+   authenticate with.
+3. **Sign in** — one registry login with that token.
+4. **Install** — pick your mode and version; the download commands are built for
+   your team, with the registry host, artifact references, and the version you pick
+   already filled in. The same step downloads the **documentation bundle** for that
+   version — the runbook or guide the other pages here refer to. See
+   [Releases](/developer-guide/self-hosting/enterprise-releases) for how versions work.
+
+Below the steps, the **License card** holds the certificate and key bundle the
+deployment needs before it will serve. Some contracts bind it to specific GPUs —
+have the card UUIDs ready when you request it.
 
 <Note>
   The registry host, the artifact references, and the versions available to you are

--- a/developer-guide/self-hosting/requirements.mdx
+++ b/developer-guide/self-hosting/requirements.mdx
@@ -72,7 +72,7 @@ on the nodes that host it, plus headroom for rewrites.
 | GPU runtime       | NVIDIA GPU Operator, or the provider-managed driver and device plugin stack. GPU nodes must expose `nvidia.com/gpu`.                                                     |
 | GPU telemetry     | DCGM exporter or the provider equivalent.                                                                                                                                |
 | Storage           | EFS, NFS, or an equivalent shared filesystem mounted on every node.                                                                                                      |
-| Object storage    | Not required. Models are served from inside the cluster in every delivery form. Hosting the weights in your own bucket instead is possible; ask your account team.                        |
+| Object storage    | Not required by default: models are served from inside the cluster. The online profile can pull them from S3-compatible storage instead — see [Kubernetes deployment](/developer-guide/self-hosting/kubernetes). |
 | Redis             | Installed by the chart into the release namespace. Do not point the release at a shared Redis without discussing it first.                                               |
 | Metrics           | Prometheus, scraping `prometheus.io/*` pod annotations. The chart creates no ServiceMonitors, so kube-prometheus-stack users must add an annotation-based scrape config. |
 | Access layer      | Yours to choose. Ingress controller, DNS, TLS, and load balancing are not part of the delivery.                                                                          |
@@ -87,8 +87,8 @@ permits `hostPID` and `hostIPC`, which the inference workers require.
 | Direction                    | Requirement                                                                                                                                                                                                              |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Install-time egress          | Access to the Fish Audio registry to pull images and the chart. Mirror both into your own registry for air-gapped installs.                                                                                              |
-| Runtime egress, offline form | None. No model download and no billing call.                                                                                                                                                                             |
-| Runtime egress, online form  | HTTPS to the Fish Audio authorization and billing endpoint. Models are served from inside the cluster, so no object-store endpoint has to be reachable. Ask your account team for the billing hostname to allowlist. Enabling the timestamp aligner adds one more host. |
+| Runtime egress, offline profile | None. No model download and no billing call.                                                                                                                                                                             |
+| Runtime egress, online profile  | HTTPS to the Fish Audio authorization and billing endpoint. Models are in-cluster by default; if you point the workers at an external model source, allowlist that endpoint too. Ask your account team for the billing hostname to allowlist. Enabling the timestamp aligner adds one more host. |
 | Ingress                      | Customer-approved ingress or a private endpoint, with DNS and TLS in place before production traffic.                                                                                                                    |
 
 ## All-in-One container host
@@ -96,14 +96,14 @@ permits `hostPID` and `hostIPC`, which the inference workers require.
 | Requirement       | Detail                                                                                                                           |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | OS                | Linux x86-64.                                                                                                                    |
-| GPUs              | 2 GPUs, 32 GB of memory or larger. The first runs the inference worker, the second runs the vocoder. No NVLink required.                                    |
-| NVIDIA driver     | Must support CUDA 13.x and your card's compute capability. This applies to the Kubernetes forms too: a driver capped at CUDA 12 reports a healthy GPU and then fails the workloads. |
+| GPUs              | 1–2 GPUs, no NVLink required. Dual-GPU modes run the inference worker and the vocoder on a card each; the Single-GPU mode runs both on one 80 GB-class card. |
+| NVIDIA driver     | Must support CUDA 13.x and your card's compute capability. This applies to the Helm platform too: a driver capped at CUDA 12 reports a healthy GPU and then fails the workloads. |
 | Docker            | Docker Engine 24 or newer.                                                                                                       |
 | Container toolkit | NVIDIA Container Toolkit installed and the `nvidia` runtime registered, so `--gpus all` exposes GPUs.                            |
 | RAM               | 128 GiB minimum, 192 GiB recommended. The container runs the whole stack in one process tree.                                    |
 | CPU               | 32 vCPU minimum, 48 to 64 recommended.                                                                                           |
 | Disk              | 100 GB free if the host pulls the image itself; 120 GB if you move it as a file, since `docker load` needs the ~30 GB archive and the ~80 GB unpacked image at once. Plus the compile and engine caches. |
-| Network           | Offline form: none at runtime. Online form: outbound HTTPS to the Fish Audio authorization and billing endpoint, on every request. Ask your account team for the hostname to allowlist. |
+| Network           | Offline mode: none at runtime. Online mode: outbound HTTPS to the Fish Audio authorization and billing endpoint, on every request. Ask your account team for the hostname to allowlist. |
 | License bundle    | The certificate and key pair from **Developer → Self Host**, in a host directory readable by the container's non-root user.       |
 
 ## Next step


### PR DESCRIPTION
Public self-hosting section caught up to the released reality: platforms × composable mode axes (billing/topology/weights) replacing the four-forms table, the Helm online profile's S3-compatible model source, the Single-GPU and external-weights All-in-One variants at capability level, the four-step dashboard walkthrough, and per-mode release lines. No team-specific values, no internal version numbers; details stay in the per-version delivered docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkJTcgMifLQm6D5tWnAga6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791390502&installation_model_id=430858&pr_number=171&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F171&signature=8da1065daf6a9fe62b4f1c409ce9ae9e2574cc3b88041cc716376959b7e9ed70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized self-hosting guidance around Kubernetes and All-in-One platforms, with modes defined by billing, GPU topology, and model-weight delivery.
  * Documented All-in-One support for one or two GPUs, including Single-GPU operation on an 80 GB-class card.
  * Clarified model-weight options, including S3-compatible storage for online Kubernetes deployments and runtime-mounted weights for applicable All-in-One setups.
  * Updated release tagging, Self Host installation steps, license information, and infrastructure requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->