### PR TITLE
Self-hosting docs: sync to the shipped dashboard, and review fixes

### DIFF
--- a/developer-guide/self-hosting/all-in-one.mdx
+++ b/developer-guide/self-hosting/all-in-one.mdx
@@ -18,14 +18,15 @@ other; the container logs which at startup.
 <Note>
   This page covers what the appliance is and what to plan for. The commands, tuning
   options, and troubleshooting are in the **All-in-One guide**, which ships in the
-  documentation bundle for the image version you run. See
+  deployment guide download for the image version you run. See
   [Releases](/developer-guide/self-hosting/enterprise-releases).
 </Note>
 
 ## What it cannot do
 
-The appliance runs one inference worker and one vocoder — a GPU each, or one
-shared 80 GB-class card in the Single-GPU mode. It does not
+The appliance runs one inference worker and one vocoder — a GPU each; the
+Single-GPU special case shares one H100-class 80 GB card, with lower throughput.
+It does not
 autoscale, does not shard across more GPUs or nodes, and does not ship the forced
 aligner, so it returns no word or segment timings. For elastic or higher-throughput
 deployments, use the [Kubernetes chart](/developer-guide/self-hosting/kubernetes), which
@@ -34,11 +35,12 @@ scales replicas across all GPUs and nodes.
 ## What running it involves
 
 One `docker run` on a host that meets the
-[All-in-One host requirements](/developer-guide/self-hosting/requirements#all-in-one-container-host).
+[All-in-One host requirements](/developer-guide/self-hosting/requirements#all-in-one-docker).
 It needs:
 
-- **One or two GPUs.** The Dual-GPU modes give the inference worker and the vocoder
-  a card each; the Single-GPU mode runs both on one 80 GB-class card.
+- **Two GPUs** — one for the inference worker, one for the vocoder. The Single-GPU
+  mode is a special case: one H100-class 80 GB card shared by both, with lower
+  throughput.
 - **One exposed port** for the API.
 - **One persistent volume.** Compile caches, the vocoder's built engine, reference
   voice archives, and — in the offline mode — the usage ledger all live there. Model
@@ -94,6 +96,6 @@ per voice.
 
 ## Next steps
 
-- [Requirements](/developer-guide/self-hosting/requirements#all-in-one-container-host): host baseline
-- [Registry access](/developer-guide/self-hosting/registry-access): how your team gets the image
+- [Requirements](/developer-guide/self-hosting/requirements#all-in-one-docker): host baseline
+- [Registry & license](/developer-guide/self-hosting/registry-access): how your team gets the image
 - [Air-gapped deployments](/developer-guide/self-hosting/air-gapped): moving the image to a disconnected host

--- a/developer-guide/self-hosting/introduction.mdx
+++ b/developer-guide/self-hosting/introduction.mdx
@@ -28,7 +28,7 @@ which platforms — and which modes of each — your team is granted.
 
 |          | Helm (Kubernetes)                                                              | All-in-One (Docker)                                    |
 | -------- | ------------------------------------------------------------------------------ | ------------------------------------------------------ |
-| Shape    | The chart on your cluster: replicas across GPUs and nodes, rolling upgrades.   | One container on one GPU host; the smallest footprint. |
+| Shape    | The chart on your cluster: replicas across GPUs and nodes, rolling upgrades.   | One container on a single machine; the smallest footprint. |
 | Best for | Production clusters and elastic capacity.                                       | Evaluation, fixed-size appliances, strict air gaps.    |
 
 A **mode** is a combination of the axes below; on Helm only billing is a mode —
@@ -42,13 +42,16 @@ runs air-gapped.
 | Axis     | All-in-One                                                                                          | Helm                                                                                                                |
 | -------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | Billing  | Online or Offline.                                                                                  | The same two, as deployment profiles of one chart — a values file selects the profile.                               |
-| Topology | **Dual-GPU** — worker and vocoder on a card each. **Single-GPU** — both share one 80 GB-class card. | Not a mode — each component takes a whole GPU; you add replicas to grow.                                             |
+| Topology | **Dual-GPU** — worker and vocoder on a card each. **Single-GPU** — a special case: both share one H100-class 80 GB card, with lower throughput. | Not a mode — each component takes a whole GPU; you add replicas to grow.                                             |
 | Weights  | **Baked** into the image, or **external** — mounted at run time.                                    | In-cluster by default; the online profile can instead pull from S3-compatible storage — see [Kubernetes deployment](/developer-guide/self-hosting/kubernetes). |
 
 The offline modes are air-gap capable — the Helm profile after mirroring images
 and the chart into your own registry.
 
-Combinations beyond this standard set can be discussed with your account team.
+Choose the platform and mode that fit your constraints, then agree them with
+your Fish Audio account team — your agreement determines what **Developer →
+Self Host** offers you. Combinations beyond this standard set can be discussed
+there too.
 
 Both Helm profiles share one deployment procedure and differ only in a few values.
 See [Kubernetes deployment](/developer-guide/self-hosting/kubernetes) for the
@@ -115,8 +118,8 @@ configure.
   <Step title="Create a deploy token">
     Sign in to fish.audio and open **Developer → Self Host** to see the
     platforms and modes your team is granted and to create the token that
-    authenticates against the registry. See [Registry
-    access](/developer-guide/self-hosting/registry-access).
+    authenticates against the registry. See
+    [Registry & license](/developer-guide/self-hosting/registry-access).
   </Step>
 </Steps>
 
@@ -131,7 +134,7 @@ configure.
     GPU, CPU, memory, storage, and platform baselines.
   </Card>
   <Card
-    title="Registry access"
+    title="Registry & license"
     icon="key"
     href="/developer-guide/self-hosting/registry-access"
   >

--- a/developer-guide/self-hosting/kubernetes.mdx
+++ b/developer-guide/self-hosting/kubernetes.mdx
@@ -11,7 +11,7 @@ they differ only in how usage is accounted.
 <Note>
   This page covers what the deployment involves and what you need to decide. The
   commands, values, and troubleshooting are in the **deployment runbook**, which ships
-  in the documentation bundle alongside the chart version you install. See
+  in the deployment guide download for the chart version you install. See
   [Releases](/developer-guide/self-hosting/enterprise-releases). The runbook is
   versioned with the chart; this page is not, so follow the runbook when they differ.
 </Note>
@@ -23,6 +23,12 @@ they differ only in how usage is accounted.
 | Usage accounting | Local signed ledger on shared storage            | Validated and billed against the Fish Audio service |
 | Runtime egress   | None                                             | The billing endpoint on 443 — plus the model-source endpoint, if you use one |
 | Model assets     | Served in-cluster by the bundled model warehouse | In-cluster by default; can instead pull from S3-compatible storage |
+
+The bearer-token rules follow the profile: online requests must carry a
+[Fish Audio API key](/developer-guide/getting-started/api-key) with credit, while
+offline accepts any stable non-empty token and records it verbatim as the billing
+identity — the same semantics as the
+[All-in-One's usage accounting](/developer-guide/self-hosting/all-in-one#usage-accounting-and-tenancy).
 
 Both profiles serve model weights from inside the cluster by default. The online
 profile can point the workers at S3-compatible storage instead — Fish Audio's
@@ -82,5 +88,5 @@ the order to do them in and what to check at each step.
 ## Next steps
 
 - [Requirements](/developer-guide/self-hosting/requirements): hardware, platform, and network baselines
-- [Registry access](/developer-guide/self-hosting/registry-access): how your team gets the chart
+- [Registry & license](/developer-guide/self-hosting/registry-access): how your team gets the chart
 - [Operations](/developer-guide/self-hosting/operations): running it once it is live

--- a/developer-guide/self-hosting/operations.mdx
+++ b/developer-guide/self-hosting/operations.mdx
@@ -44,7 +44,7 @@ Capacity is changed through the release configuration: API replicas, GPU worker
 replicas, CPU and memory requests, GPU resource requests, and per-worker concurrency.
 All of it takes effect on an upgrade. Scaling on load instead of by hand is included
 and off by default; while it is on, the replica count is the autoscaler's rather than
-the file's. Your documentation bundle covers turning it on.
+the file's. Your deployment guide covers turning it on.
 
 Add a GPU replica only when a GPU is actually free: a pod that requests one on a full
 cluster stays `Pending` indefinitely.
@@ -91,7 +91,7 @@ until the new one is accepted.
 
 The failures a Kubernetes deployment actually produces, and where each one usually
 comes from. The commands to diagnose each, and the fixes, are in the troubleshooting
-guide that ships in your documentation bundle.
+guide that ships with your deployment guide.
 
 | Symptom                                                                  | Likely causes                                                                                                                                                                                      |
 | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/developer-guide/self-hosting/registry-access.mdx
+++ b/developer-guide/self-hosting/registry-access.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Registry access"
-description: "The Self Host dashboard, deploy tokens, and how your team reaches the Fish Audio registry"
+title: "Registry & license"
+description: "The Self Host dashboard: deploy tokens, registry sign-in, and your license bundle"
 icon: "key"
 ---
 
@@ -10,24 +10,21 @@ dashboard.
 
 ## The Self Host page
 
-Sign in to fish.audio and open **Developer → Self Host**. The page walks your team
-through four steps:
+Sign in to fish.audio and open **Developer → Self Host**. The page opens with
+**Before you start** — the platforms and modes your team is granted, with the
+prerequisites it checks. If it is empty, or reports that self-host deployment
+is not enabled, contact your account manager. Then four steps:
 
-1. **Choose your platform** — the platforms and modes your team is granted, and the
-   prerequisites to check first. If the page is empty, or reports that self-host
-   deployment is not enabled, contact your account manager.
-2. **Deploy token** — create the credential the install commands in step 4
-   authenticate with.
-3. **Sign in** — one registry login with that token.
+1. **Deploy token** — create the credential the install commands authenticate with.
+2. **Sign in** — one registry login with that token.
+3. **License** — download the certificate and key bundle the deployment needs
+   before it will serve, at first install and at every renewal. Some contracts
+   bind it to specific GPUs — have the card UUIDs ready when you request it.
 4. **Install** — pick your mode and version; the download commands are built for
    your team, with the registry host, artifact references, and the version you pick
-   already filled in. The same step downloads the **documentation bundle** for that
+   already filled in. The same step downloads the **deployment guide** for that
    version — the runbook or guide the other pages here refer to. See
    [Releases](/developer-guide/self-hosting/enterprise-releases) for how versions work.
-
-Below the steps, the **License card** holds the certificate and key bundle the
-deployment needs before it will serve. Some contracts bind it to specific GPUs —
-have the card UUIDs ready when you request it.
 
 <Note>
   The registry host, the artifact references, and the versions available to you are
@@ -44,7 +41,7 @@ have the card UUIDs ready when you request it.
 ## Create a deploy token
 
 <Steps>
-  <Step title="Open the Deploy Tokens card">
+  <Step title="Open the Deploy token step">
     On **Developer → Self Host**, select **Create Deploy Token**.
   </Step>
   <Step title="Name it for where it will be used">
@@ -80,6 +77,30 @@ Recommended practice:
 - Store tokens in your secret manager, not in values files or version control.
 - Rotate on your normal credential schedule and whenever someone with access to a token
   leaves the team.
+
+## The license
+
+The license is the product permit: every platform and billing mode needs one to
+run, and it is separate from how usage is billed. Fish Audio issues the
+license against your contract, and the dashboard's License step is
+where you download the bundle — a certificate (`license.crt`) and key
+(`license.key`) that the deployment mounts, as its guide's License section
+shows. Some contracts bind the license to specific GPU UUIDs; the dashboard
+shows the binding.
+
+The two failure modes are worth knowing before they happen. **Missing**, the
+services never come up. **Expired**, they start but refuse every request with a
+license error (403) until the renewed bundle is in place.
+
+**Validity and renewal.** The certificate carries a validity window bounded by
+your contract term; the dashboard shows the current expiry. Renewals are driven
+by Fish Audio: before the expiry, settle the period's invoice — and, on offline
+billing, send the usage ledger for reconciliation — and a renewed license is
+issued. A renewal replaces only `license.crt`, in place, and the running
+services reload it without a restart; only a bundle that carries a new key
+needs one. The Helm-side mechanics are in
+[License renewal](/developer-guide/self-hosting/operations#license-renewal);
+the All-in-One's are in its deployment guide.
 
 ## Next step
 

--- a/developer-guide/self-hosting/requirements.mdx
+++ b/developer-guide/self-hosting/requirements.mdx
@@ -9,7 +9,11 @@ account team once your traffic profile and target GPU are known: time-to-first-a
 and throughput depend on the model, GPU, text length, and concurrency, and should be
 measured on your own hardware before you commit to a capacity plan.
 
-## Kubernetes deployments
+## Helm (Kubernetes)
+
+Everything in this section — cluster topology, GPUs, shared storage, platform
+baseline, and network — is for the Helm platform. The All-in-One's host requirements,
+including its own network row, are the [next section](#all-in-one-docker).
 
 ### Cluster topology
 
@@ -91,12 +95,12 @@ permits `hostPID` and `hostIPC`, which the inference workers require.
 | Runtime egress, online profile  | HTTPS to the Fish Audio authorization and billing endpoint. Models are in-cluster by default; if you point the workers at an external model source, allowlist that endpoint too. Ask your account team for the billing hostname to allowlist. Enabling the timestamp aligner adds one more host. |
 | Ingress                      | Customer-approved ingress or a private endpoint, with DNS and TLS in place before production traffic.                                                                                                                    |
 
-## All-in-One container host
+## All-in-One (Docker)
 
 | Requirement       | Detail                                                                                                                           |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | OS                | Linux x86-64.                                                                                                                    |
-| GPUs              | 1–2 GPUs, no NVLink required. Dual-GPU modes run the inference worker and the vocoder on a card each; the Single-GPU mode runs both on one 80 GB-class card. |
+| GPUs              | 2 GPUs, no NVLink required — one for the inference worker, one for the vocoder. The Single-GPU mode is a special case: one H100-class 80 GB card shared by both, with lower throughput. |
 | NVIDIA driver     | Must support CUDA 13.x and your card's compute capability. This applies to the Helm platform too: a driver capped at CUDA 12 reports a healthy GPU and then fails the workloads. |
 | Docker            | Docker Engine 24 or newer.                                                                                                       |
 | Container toolkit | NVIDIA Container Toolkit installed and the `nvidia` runtime registered, so `--gpus all` exposes GPUs.                            |
@@ -109,4 +113,4 @@ permits `hostPID` and `hostIPC`, which the inference workers require.
 ## Next step
 
 Once the platform checks pass, authenticate to the Fish Audio registry in
-[Registry access](/developer-guide/self-hosting/registry-access).
+[Registry & license](/developer-guide/self-hosting/registry-access).


### PR DESCRIPTION
Follow-up to #171 — these amendments were pushed to the merged branch after it landed, so they never reached main:

- registry-access: the dashboard walkthrough matches the shipped page — Before you start, then 1 Deploy token / 2 Sign in / 3 License / 4 Install; the download is named the deployment guide, with the documentation-bundle term bridged at its definition; card vocabulary removed.
- introduction: Single-GPU stated as a special case (one H100-class 80 GB card, lower throughput); pick-your-mode-then-agree-with-your-account-team guidance.
- requirements + all-in-one: the same Single-GPU/2-GPU accuracy pass.
- kubernetes: bearer-token rules per billing profile (online needs a funded API key; offline records any stable token as the billing identity).

All content was reviewed to sign-off in the #171 review threads; this PR only carries it to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkJTcgMifLQm6D5tWnAga6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791436211&installation_model_id=430858&pr_number=172&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F172&signature=c6146009ea6af1a884b502a3f73112ee8547f8887d93e644acecdf895d5afa7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosting guidance to organize deployment around Helm and All-in-One platforms.
  * Clarified billing profiles, deployment modes, model-weight options, GPU requirements, storage, networking, and external model sources.
  * Added details for Single-GPU H100-class 80 GB All-in-One deployments.
  * Renamed “Registry access” guidance to “Registry & license” and clarified the required access and installation steps.
  * Improved navigation links and terminology across self-hosting documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->