### PR TITLE
docs(agents): speaking language adds pt, it, nl

### DIFF
--- a/agents/build/configuration.mdx
+++ b/agents/build/configuration.mdx
@@ -34,7 +34,7 @@ Choose how the agent opens each conversation:
 
 ## Voice
 
-The Voice panel selects the voice your agent speaks with (`voice_id`), its speaking language (`speaking_language`: `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`), and whether it speaks expressively (`expressive`, default `false`). See [Voice & language](/agents/build/voice-language) for picking a voice and [Expressive mode](/agents/build/voice-language#expressive-mode) for expressive delivery.
+The Voice panel selects the voice your agent speaks with (`voice_id`), its speaking language (`speaking_language`: `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`, `pt`, `it`, `nl`), and whether it speaks expressively (`expressive`, default `false`). See [Voice & language](/agents/build/voice-language) for picking a voice and [Expressive mode](/agents/build/voice-language#expressive-mode) for expressive delivery.
 
 ## Conversation settings
 

--- a/agents/build/dynamic-variables.mdx
+++ b/agents/build/dynamic-variables.mdx
@@ -105,7 +105,7 @@ The platform fills a handful of `{{system.*}}` placeholders itself, on every ses
 | `system.channel` | `phone_inbound`, `phone_outbound`, or `web_voice` | Web SDK, API, preview, and agent test sessions are all `web_voice`. |
 | `system.timezone` | The session's resolved IANA timezone, for example `Asia/Shanghai` | `UTC` when nothing resolves. Always equals the session's `timezone` field; see [which timezone a session uses](/agents/build/time-timezone#which-timezone-a-session-uses). |
 | `system.today` | Today's date in that timezone, ISO 8601 `YYYY-MM-DD` | The calendar date at session creation. There is no `system.now`; see [World context](#world-context). |
-| `system.language` | The session language id: `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de` | The `language` [override](/agents/deploy/authenticated-sessions#overrides) when the request carries one, otherwise the agent's [speaking language](/agents/build/voice-language#speaking-language). |
+| `system.language` | The session language id: `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`, `pt`, `it`, `nl` | The `language` [override](/agents/deploy/authenticated-sessions#overrides) when the request carries one, otherwise the agent's [speaking language](/agents/build/voice-language#speaking-language). |
 | `system.caller_number` | The human party's number, E.164 | Inbound: the caller (empty if withheld or not a valid E.164 number). Outbound: the number you dialed. Empty on non-phone sessions. |
 | `system.dialed_number` | Your workspace number, E.164 | Inbound: the number that was called. Outbound: the number the call was placed from. Empty on non-phone sessions. |
 

--- a/agents/build/voice-language.mdx
+++ b/agents/build/voice-language.mdx
@@ -65,7 +65,7 @@ curl --request PATCH "https://api.fish.audio/v1/agent/agents/$AGENT_ID/config" \
 
 ## Speaking language
 
-**Speaking language** sets the language for the agent's conversations: one of `en`, `ja`, `zh`, `ko`, `es`, `fr`, or `de` (`voice.speaking_language` on the wire). Every session converses in this language.
+**Speaking language** sets the language for the agent's conversations: one of `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`, `pt`, `it`, or `nl` (`voice.speaking_language` on the wire). Every session converses in this language.
 
 <Note>
   The voice model and the speaking language are independent settings: picking a voice does not change the language, and vice versa. Choose a voice that sounds natural in the language you configure.

--- a/agents/deploy/authenticated-sessions.mdx
+++ b/agents/deploy/authenticated-sessions.mdx
@@ -143,7 +143,7 @@ Unknown fields (top-level or inside `overrides`) are rejected with `422`.
 | `first_message_prompt` | string, up to 10,000 characters          | Instructions the agent generates its opener from, replacing the configured first-message behavior. `{{placeholders}}` render inside it. Mutually exclusive with `first_message`: sending both is `422`.          |
 | `system_prompt`        | string, up to 32,000 tokens              | Replaces the configured system prompt entirely, under the same token budget. `{{placeholders}}` render inside it.                                                                                                 |
 | `voice_id`             | string                                   | The voice the agent speaks with: any [voice model id](/agents/build/voice-language#use-any-voice-model) from the Voice Library. Voices bias pronunciation toward their own language, so pair it with `language`. |
-| `language`             | `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de` | Pins the conversation language, taking precedence over the configured [speaking language](/agents/build/voice-language#speaking-language).                                                                        |
+| `language`             | `en`, `ja`, `zh`, `ko`, `es`, `fr`, `de`, `pt`, `it`, `nl` | Pins the conversation language, taking precedence over the configured [speaking language](/agents/build/voice-language#speaking-language).                                                                        |
 
 ```json
 {


### PR DESCRIPTION
Language code lists for `speaking_language`, session `language`, and `system.language` gain `pt`, `it`, `nl`. Merge after the platform accepts them in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791464163&installation_model_id=430858&pr_number=173&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F173&signature=250ad3151a3a1c310f00ae83c91cf77463e958d7154282c6d6c50d00303005b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated language support documentation to include Portuguese, Italian, and Dutch for voice settings and authenticated sessions.
  - Added Italian and Dutch as supported system language values for dynamic variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->