### PR TITLE
docs: add WebSocket TTS with timestamps reference

### DIFF
--- a/api-reference/endpoint/openapi-v1/text-to-speech-live-with-timestamps.mdx
+++ b/api-reference/endpoint/openapi-v1/text-to-speech-live-with-timestamps.mdx
@@ -1,0 +1,48 @@
+---
+openapi: get /v1/tts/live/with-timestamp
+title: "WebSocket TTS with Timestamps"
+description: "Stream text and receive speech with word-level timestamps over WebSocket"
+icon: "webhook"
+iconType: "solid"
+---
+
+<Note>
+  Connect to `wss://api.fish.audio/v1/tts/live/with-timestamp` with a WebSocket
+  client. The endpoint requires a WebSocket upgrade and returns MessagePack
+  binary frames. A normal HTTP GET request does not start synthesis.
+</Note>
+
+## Before you start
+
+You need a [Fish Audio API key](/developer-guide/getting-started/api-key) and a
+WebSocket client that supports custom authentication headers. To run the Python
+example on this page, install its dependencies:
+
+```bash
+pip install ormsgpack websockets
+```
+
+Replace `<token>` in the example with your API key and set `reference_id` to your
+voice model ID. The `start.request` object accepts the same parameters as the
+[Text to Speech API](/api-reference/endpoint/openapi-v1/text-to-speech).
+Send text and receive audio concurrently, then keep reading after sending `stop`
+until the server sends `finish`.
+
+## Preserve the final timestamps
+
+Process alignment metadata even when an `audio` event contains empty audio bytes:
+a trailing event can carry a final alignment correction. Store each non-null
+`alignment` by `chunk_seq`, replacing its previous snapshot. A null alignment
+does not erase a snapshot you already received.
+
+Add `chunk_audio_offset_sec` to each segment's `start` and `end` to place it on
+the session's audio timeline. The optional `time` field measures elapsed server
+session time in milliseconds; use the segment timestamps for captions.
+
+After `finish`, you can send another `start` on the same socket. Reset your audio
+buffer and stored alignment snapshots for the new session.
+
+## Related endpoints
+
+- [Text to Speech Stream with Timestamps](/api-reference/endpoint/openapi-v1/text-to-speech-stream-with-timestamps): send the full text in one HTTP request and receive audio and timestamps over SSE.
+- [WebSocket TTS Streaming](/api-reference/endpoint/websocket/tts-live): stream text and audio without timestamps.

--- a/docs.json
+++ b/docs.json
@@ -282,6 +282,7 @@
                 "pages": [
                   "api-reference/endpoint/openapi-v1/text-to-speech",
                   "api-reference/endpoint/openapi-v1/text-to-speech-stream-with-timestamps",
+                  "api-reference/endpoint/openapi-v1/text-to-speech-live-with-timestamps",
                   "api-reference/endpoint/openapi-v1/speech-to-text",
                   "api-reference/endpoint/websocket/tts-live"
                 ]


### PR DESCRIPTION
The WebSocket TTS endpoint with timestamps is already described in the OpenAPI schema, but has no documentation page or navigation entry. Add **WebSocket TTS with Timestamps** to **TTS & ASR (v1)** immediately after the HTTP timestamp streaming page.

The page reuses the existing OpenAPI protocol and Python example, with guidance on dependencies, final alignment corrections, chunk-relative timestamps, and resetting state when reusing a socket.

Validation:
- OpenAPI validation passed; local schema matches the canonical API schema.
- New page formatting, navigation target, Python example syntax, and diff whitespace checks passed.
- Link checking reports 22 existing broken links in unrelated files; none involve this change.
- Full `mint validate` is unavailable in the installed CLI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/fishaudio/codesmith/docs/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791696527&installation_model_id=430858&pr_number=183&repository=fishaudio%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Ffishaudio%2Fdocs%2Fpull%2F183&signature=19b3901b74688a6a22502774071c8c83d9efd5b8d283428dd63805104f2f155c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the WebSocket text-to-speech endpoint with word-level timestamps.
  * Described connection requirements, MessagePack responses, concurrent audio streaming, completion handling, and timestamp alignment.
  * Added setup instructions and links to related endpoints.
  * Added the new page to the API Reference navigation under TTS & ASR (v1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->